### PR TITLE
chore(keycloak): upgrade image to 26.7 and guard version drift

### DIFF
--- a/.github/workflows/build-keycloak.yml
+++ b/.github/workflows/build-keycloak.yml
@@ -29,6 +29,9 @@ jobs:
           KC_VERSION=$(grep '^FROM' deploy/docker-compose/dokploy/keycloak/Dockerfile | grep -oP '(?<=keycloak:)\S+')
           echo "keycloak_version=$KC_VERSION" >> "$GITHUB_OUTPUT"
 
+      - name: Check no pinned Keycloak reference has drifted
+        run: sh ./deploy/docker-compose/dokploy/keycloak/check-keycloak-version.sh
+
       - name: Build image
         run: docker build -t ghcr.io/openfilz/keycloak:${{ steps.version.outputs.keycloak_version }} deploy/docker-compose/dokploy/keycloak
 

--- a/deploy/docker-compose/.env.example
+++ b/deploy/docker-compose/.env.example
@@ -80,7 +80,7 @@ OPENFILZ_SOFTDELETE_ACTIVE=true
 OPENFILZ_CALCULATECHECKSUM=false
 
 # Keycloak settings (only used when OPENFILZ_SECURITY_NO_AUTH=false)
-KEYCLOAK_IMAGE=ghcr.io/openfilz/keycloak:26.5
+KEYCLOAK_IMAGE=ghcr.io/openfilz/keycloak:26.7
 KEYCLOAK_ADMIN=admin
 KEYCLOAK_ADMIN_PASSWORD=admin
 KEYCLOAK_PORT=8180

--- a/deploy/docker-compose/README.md
+++ b/deploy/docker-compose/README.md
@@ -271,7 +271,7 @@ Used with `docker-compose.auth.yml`:
 | `KEYCLOAK_ADMIN` | `admin` | Keycloak bootstrap admin username (maps to `KC_BOOTSTRAP_ADMIN_USERNAME`) |
 | `KEYCLOAK_ADMIN_PASSWORD` | `admin` | Keycloak bootstrap admin password (maps to `KC_BOOTSTRAP_ADMIN_PASSWORD`) |
 | `KEYCLOAK_PORT` | `8180` | Keycloak exposed port |
-| `KEYCLOAK_IMAGE` | `ghcr.io/openfilz/keycloak:26.5` | Custom Keycloak Docker image |
+| `KEYCLOAK_IMAGE` | `ghcr.io/openfilz/keycloak:26.7` | Custom Keycloak Docker image |
 | `KEYCLOAK_MANAGEMENT_PORT` | `9000` | Keycloak management port |
 | `KEYCLOAK_REALM_URL` | `http://keycloak:8080/realms/openfilz` | Internal Docker URL for Keycloak realm (used by API for JWK fetching) |
 | `KEYCLOAK_DB_USER` | `keycloak` | Keycloak database user |

--- a/deploy/docker-compose/docker-compose.auth.yml
+++ b/deploy/docker-compose/docker-compose.auth.yml
@@ -14,7 +14,7 @@ services:
   # Keycloak Authentication Server
   # =============================================================================
   keycloak:
-    image: ${KEYCLOAK_IMAGE:-ghcr.io/openfilz/keycloak:26.5}
+    image: ${KEYCLOAK_IMAGE:-ghcr.io/openfilz/keycloak:26.7}
     container_name: openfilz-keycloak
     restart: unless-stopped
     environment:

--- a/deploy/docker-compose/dokploy/.env.example
+++ b/deploy/docker-compose/dokploy/.env.example
@@ -46,7 +46,7 @@ CORS_ALLOWED_ORIGINS=https://app.yourdomain.com,https://docs.yourdomain.com
 # =============================================================================
 # Security Configuration (Keycloak)
 # =============================================================================
-KEYCLOAK_IMAGE=ghcr.io/openfilz/keycloak:26.5
+KEYCLOAK_IMAGE=ghcr.io/openfilz/keycloak:26.7
 KEYCLOAK_ADMIN=admin
 KEYCLOAK_ADMIN_PASSWORD=change-this-admin-password
 KEYCLOAK_CLIENT_ID=openfilz-web

--- a/deploy/docker-compose/dokploy/README.md
+++ b/deploy/docker-compose/dokploy/README.md
@@ -169,7 +169,7 @@ Click **Deploy** and wait for all services to start (this may take a few minutes
 
 ## Custom Keycloak Image
 
-This deployment uses a custom Keycloak image (`ghcr.io/openfilz/keycloak:26.5`) that includes:
+This deployment uses a custom Keycloak image (`ghcr.io/openfilz/keycloak:26.7`) that includes:
 
 - **Pre-imported realm**: The OpenFilz realm configuration is baked into the image
 - **Custom themes**: OpenFilz-branded login and email themes
@@ -182,9 +182,26 @@ cd keycloak/
 ./build-push-keycloak-image.sh
 ```
 
+### Upgrading the Keycloak version
+
+`keycloak/Dockerfile`'s `FROM` line is the **single source of truth** for the
+Keycloak version. The build script and the `build-keycloak.yml` workflow both
+derive the published tag from it, so they cannot disagree.
+
+The other references (compose defaults, `.env` values, Helm values, docs) carry a
+concrete tag on purpose. To keep them honest, `keycloak/check-keycloak-version.sh`
+fails if any of them drifts from the Dockerfile; it runs in CI and at the start of
+the build script. After bumping the `FROM` line, run it to see everything still to
+update:
+
+```bash
+cd keycloak/
+./check-keycloak-version.sh
+```
+
 To use a specific version, set:
 ```env
-KEYCLOAK_IMAGE=ghcr.io/openfilz/keycloak:26.5
+KEYCLOAK_IMAGE=ghcr.io/openfilz/keycloak:26.7
 ```
 
 ## Keycloak Database Initialization

--- a/deploy/docker-compose/dokploy/compose.yaml
+++ b/deploy/docker-compose/dokploy/compose.yaml
@@ -50,7 +50,7 @@ services:
   # Keycloak Authentication Server
   # =============================================================================
   keycloak:
-    image: ${KEYCLOAK_IMAGE:-ghcr.io/openfilz/keycloak:26.5}
+    image: ${KEYCLOAK_IMAGE:-ghcr.io/openfilz/keycloak:26.7}
     restart: unless-stopped
     pull_policy: always
     command:

--- a/deploy/docker-compose/dokploy/keycloak/Dockerfile
+++ b/deploy/docker-compose/dokploy/keycloak/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/keycloak/keycloak:26.5
+FROM quay.io/keycloak/keycloak:26.7
 
 LABEL org.opencontainers.image.source="https://github.com/openfilz/openfilz-core"
 

--- a/deploy/docker-compose/dokploy/keycloak/build-push-keycloak-image.sh
+++ b/deploy/docker-compose/dokploy/keycloak/build-push-keycloak-image.sh
@@ -3,7 +3,25 @@ set -e
 
 # Build and push the OpenFilz Community Edition Keycloak image
 # Run from: openfilz-core/deploy/docker-compose/dokploy/keycloak/
+#
+# The Keycloak version is NOT hardcoded here: it is read from the Dockerfile's
+# FROM line, which is the single source of truth for the whole repo. The
+# build-keycloak.yml workflow derives the tag the same way, so a local build and
+# a CI build can never disagree.
 
-docker build -t ghcr.io/openfilz/keycloak:26.5 .
+KC_VERSION=$(sed -n 's|^FROM  *quay\.io/keycloak/keycloak:\(.*\)$|\1|p' Dockerfile)
+if [ -z "$KC_VERSION" ]; then
+  echo "ERROR: could not read the Keycloak version from the Dockerfile FROM line" >&2
+  exit 1
+fi
 
-docker push ghcr.io/openfilz/keycloak:26.5
+IMAGE="ghcr.io/openfilz/keycloak:$KC_VERSION"
+
+# Fail early if any pinned reference elsewhere in the repo disagrees.
+sh ./check-keycloak-version.sh
+
+echo "Building $IMAGE"
+docker build -t "$IMAGE" .
+
+echo "Pushing $IMAGE"
+docker push "$IMAGE"

--- a/deploy/docker-compose/dokploy/keycloak/check-keycloak-version.sh
+++ b/deploy/docker-compose/dokploy/keycloak/check-keycloak-version.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+set -e
+
+# Verify that every pinned Keycloak image reference in the repo agrees with the
+# version in this directory's Dockerfile.
+#
+# The Dockerfile FROM line is the single source of truth. The remaining
+# references are deployment configuration (compose defaults, .env values, Helm
+# values) and documentation, which legitimately carry a concrete tag rather than
+# deriving one — so instead of removing them, this guard makes them verifiable.
+#
+# Run from: openfilz-core/deploy/docker-compose/dokploy/keycloak/
+# Exits non-zero and lists the offenders if anything has drifted.
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR" && git rev-parse --show-toplevel 2>/dev/null || true)
+if [ -z "$REPO_ROOT" ]; then
+  REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/../../../.." && pwd)
+fi
+
+KC_VERSION=$(sed -n 's|^FROM  *quay\.io/keycloak/keycloak:\(.*\)$|\1|p' "$SCRIPT_DIR/Dockerfile")
+if [ -z "$KC_VERSION" ]; then
+  echo "ERROR: could not read the Keycloak version from $SCRIPT_DIR/Dockerfile" >&2
+  exit 1
+fi
+
+echo "Expected Keycloak version (from Dockerfile): $KC_VERSION"
+
+# Every "<something>keycloak:<version>" / "keycloak-ee:<version>" pin in the repo.
+# Note "keycloak:8080" (the internal Docker DNS URL) does not match, as the
+# pattern requires a dotted version.
+matches=$(grep -rEn --binary-files=without-match \
+  --exclude-dir=target --exclude-dir=node_modules --exclude-dir=.git --exclude-dir=.idea \
+  'keycloak(-ee)?:[0-9]+\.[0-9]+(\.[0-9]+)?' "$REPO_ROOT" 2>/dev/null || true)
+
+drift=$(echo "$matches" | grep -vE "keycloak(-ee)?:${KC_VERSION}([^0-9.]|$)" | grep -E 'keycloak(-ee)?:[0-9]' || true)
+
+if [ -n "$drift" ]; then
+  echo "ERROR: Keycloak version drift — the following pins do not match $KC_VERSION:" >&2
+  echo "$drift" >&2
+  exit 1
+fi
+
+count=$(echo "$matches" | grep -cE 'keycloak(-ee)?:[0-9]' || true)
+echo "OK: all $count pinned Keycloak references are on $KC_VERSION"

--- a/deploy/helm/openfilz-shared/README.md
+++ b/deploy/helm/openfilz-shared/README.md
@@ -88,7 +88,7 @@ validation, full-text indexing and thumbnails.
 
 ## Replacing the Keycloak image
 
-The default `images.keycloak` (`ghcr.io/openfilz/keycloak:26.5`, public, built
+The default `images.keycloak` (`ghcr.io/openfilz/keycloak:26.7`, public, built
 from `deploy/docker-compose/dokploy/keycloak/`) bakes the **realm export**
 (the initial load) + the OpenFilz login/email themes, and its entrypoint
 substitutes `KEYCLOAK_PUBLIC_URL` / `OPENFILZ_WEB_ROOT_URL` / the default

--- a/deploy/helm/openfilz-shared/example-values/values-openshift.yaml
+++ b/deploy/helm/openfilz-shared/example-values/values-openshift.yaml
@@ -56,7 +56,7 @@ networkPolicy:
 
 # Air-gapped / proxied registries: point every image at your internal proxy.
 # images:
-#   keycloak: registry.example.com/proxy/ghcr.io/openfilz/keycloak:26.5
+#   keycloak: registry.example.com/proxy/ghcr.io/openfilz/keycloak:26.7
 #   keycloakDb: registry.example.com/proxy/docker.io/postgres:17-alpine
 #   opensearch: registry.example.com/proxy/docker.io/opensearchproject/opensearch:2.19.1
 #   gotenberg: registry.example.com/proxy/docker.io/gotenberg/gotenberg:8

--- a/deploy/helm/openfilz-shared/values.yaml
+++ b/deploy/helm/openfilz-shared/values.yaml
@@ -34,7 +34,7 @@ images:
   # the realm at import. A customized image (different baked realm, extra
   # providers) can be swapped in via this value + images.pullSecrets +
   # keycloak.extraEnv below — see "Replacing the Keycloak image" in the README.
-  keycloak: ghcr.io/openfilz/keycloak:26.5
+  keycloak: ghcr.io/openfilz/keycloak:26.7
   keycloakDb: postgres:17-alpine
   opensearch: opensearchproject/opensearch:2.19.1
   gotenberg: gotenberg/gotenberg:8

--- a/openfilz-api/src/test/java/org/openfilz/dms/e2e/SharedKeyCloakContainer.java
+++ b/openfilz-api/src/test/java/org/openfilz/dms/e2e/SharedKeyCloakContainer.java
@@ -17,10 +17,13 @@ import java.io.IOException;
  */
 public final class SharedKeyCloakContainer {
 
+    /** Pinned to the Keycloak minor shipped by deploy/docker-compose/dokploy/keycloak/Dockerfile. */
+    private static final String KEYCLOAK_IMAGE = "quay.io/keycloak/keycloak:26.7";
+
     private static final KeycloakContainer KEYCLOAK_CONTAINER;
 
     static {
-        KEYCLOAK_CONTAINER = new KeycloakContainer()
+        KEYCLOAK_CONTAINER = new KeycloakContainer(KEYCLOAK_IMAGE)
                 .withRealmImportFile("keycloak/realm-export.json")
                 .withEnv("KEYCLOAK_DEFAULT_ROLE", "READER")
                 .withEnv("KEYCLOAK_DEFAULT_GROUP", "OPENFILZ/READER")


### PR DESCRIPTION
## Why

Keycloak **26.5** (Jan 2026) is two minor releases behind the current **26.7**. Upstream Keycloak only patches the latest release — there is no 26.5 patch stream — so the image we ship to customers receives no security fixes.

## What changed

- **Base image 26.5 → 26.7** across every pinned reference (Dockerfile, build script, `.env` files, composes, Helm values, docs). The 2-part tag is kept, so rebuilds continue to pick up patch releases automatically — the running container resolves to **26.7.2**.
- **Test/prod divergence closed.** `SharedKeyCloakContainer` used `new KeycloakContainer()`, inheriting the `testcontainers-keycloak` default — so the tests ran **26.6** while the deploy images shipped **26.5**. The image is now pinned explicitly.
- **`build-push-keycloak-image.sh` derives the tag** from the Dockerfile `FROM` line instead of hardcoding it. This was the duplicate that could actually bite: script and Dockerfile could silently disagree and push an image *tagged* one version but *built from* another.
- **New `check-keycloak-version.sh`** fails when any remaining pin drifts from the Dockerfile, reporting the offending `file:line`. Compose defaults, `.env` values, Helm values and docs carry a concrete tag on purpose — removing them would change deployment behaviour — so they are guarded rather than de-duplicated. Runs in CI and at the start of the build script.

The guard is invoked as `sh ./script.sh`: this repo has `core.filemode=false` and every tracked `.sh` is mode `100644`, so a bare `./script.sh` step would fail on Linux CI with "Permission denied".

## Verification

- Image builds clean on 26.7; container starts and imports the realm successfully.
- Guard tested against injected drift (Helm values) — caught it and exited 1.
- Full `CI=true mvn clean verify`: **BUILD SUCCESS** — 555 unit + 1096 integration tests, 0 failures, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)