### PR TITLE
fix(deploy): pgvector image override + feat(ai): chat-model failover with per-provider API key pools

### DIFF
--- a/deploy/docker-compose/.env.example
+++ b/deploy/docker-compose/.env.example
@@ -8,8 +8,15 @@
 # =============================================================================
 # Database Configuration
 # =============================================================================
-# PostgreSQL version (use 16 or 17 for stability, avoid 18+ due to breaking changes)
-POSTGRES_IMAGE=postgres:17
+# PostgreSQL version (use 16 or 17 for stability, avoid 18+ due to breaking changes).
+# Leave commented out unless you need to pin a specific image/tag — docker-compose.yml
+# already defaults to postgres:17. Do NOT set this to enable AI: the AI overlay
+# (docker-compose.ai.yml / `make up-ai`) reads the separate POSTGRES_AI_IMAGE
+# variable below precisely so it isn't defeated by a POSTGRES_IMAGE pinned here.
+#POSTGRES_IMAGE=postgres:17
+# Image used only by the AI overlay (docker-compose.ai.yml / `make up-ai`); must have
+# the pgvector extension. Leave commented out to use the default (pgvector/pgvector:pg17).
+#POSTGRES_AI_IMAGE=pgvector/pgvector:pg17
 DB_NAME=dms_db
 DB_USER=dms_user
 DB_PASSWORD=dms_password

--- a/deploy/docker-compose/README.md
+++ b/deploy/docker-compose/README.md
@@ -39,6 +39,7 @@ See the [architecture diagram](../README.md#architecture) in the main deploy REA
 | `docker-compose.fulltext.yml` | OpenSearch full-text search |
 | `docker-compose-thumbnails.yml` | Gotenberg for thumbnail generation (PDF, Office documents) |
 | `docker-compose-gotenberg-dev.yml` | Gotenberg standalone for local development (IDE + npm workflow) |
+| `docker-compose.ai.yml` | AI document chat: Ollama + pgvector-enabled PostgreSQL |
 
 ---
 
@@ -86,6 +87,9 @@ make up-onlyoffice
 # Start with OpenSearch full-text search
 make up-fulltext
 
+# Start with AI document chat (Ollama)
+make up-ai
+
 # Start all CE features (no auth) for demo
 make up-demo
 
@@ -104,6 +108,9 @@ make up-auth-fulltext
 
 # Auth + OnlyOffice
 make up-auth-onlyoffice
+
+# Auth + AI chat
+make up-auth-ai
 ```
 
 ### Utility Commands
@@ -161,6 +168,26 @@ docker-compose -f docker-compose.yml -f docker-compose.fulltext.yml up -d
 docker-compose -f docker-compose.yml -f docker-compose-thumbnails.yml --profile thumbnails up -d
 ```
 
+### With AI Document Chat
+
+```bash
+docker-compose -f docker-compose.yml -f docker-compose.ai.yml up -d
+```
+
+This overlay switches the `postgres` image to a pgvector-enabled one (`pgvector/pgvector:pg17`
+by default) — AI's Flyway migration (`V1_4__add_ai_support.sql`) needs the `vector` extension,
+which a plain `postgres` image doesn't ship. It reads `POSTGRES_AI_IMAGE`, not `POSTGRES_IMAGE`,
+so it isn't defeated by a `POSTGRES_IMAGE` you've already pinned for a non-AI deployment.
+
+**Enabling AI on a deployment that was already running:** re-running `up` with this overlay is
+enough — Compose recreates the `postgres` container in place (same volume, no data loss) once it
+sees the image changed. If `openfilz-api` still fails migration with
+`extension "vector" is not available`, the `postgres` container didn't actually get the new
+image — check with `docker inspect openfilz-postgres --format '{{.Config.Image}}'` (should print
+`pgvector/pgvector:pg17`, not `postgres:17`); if it's still `postgres:17`, either `POSTGRES_IMAGE`
+is pinned in your `.env` (leave it commented out, or set `POSTGRES_AI_IMAGE` explicitly instead)
+or the overlay flag was dropped from the `up` command.
+
 ### Full Stack (All Features)
 
 ```bash
@@ -206,7 +233,8 @@ cp .env.example .env
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `POSTGRES_IMAGE` | `postgres:17` | PostgreSQL Docker image |
+| `POSTGRES_IMAGE` | `postgres:17` | PostgreSQL Docker image (base, non-AI deployments) |
+| `POSTGRES_AI_IMAGE` | `pgvector/pgvector:pg17` | PostgreSQL image used by `docker-compose.ai.yml` (`make up-ai`); must have the `vector` extension. Deliberately a separate variable from `POSTGRES_IMAGE` — see [With AI Document Chat](#with-ai-document-chat) |
 | `DB_NAME` | `dms_db` | PostgreSQL database name |
 | `DB_USER` | `dms_user` | PostgreSQL username |
 | `DB_PASSWORD` | `dms_password` | PostgreSQL password |
@@ -466,6 +494,16 @@ make clean
 
 # Start fresh
 make up
+```
+
+### AI Migration Fails: `extension "vector" is not available`
+
+The `postgres` container is running a plain `postgres` image instead of a pgvector-enabled one.
+See [With AI Document Chat](#with-ai-document-chat) above — check `POSTGRES_IMAGE` isn't pinned
+in `.env`, and confirm the running image with:
+
+```bash
+docker inspect openfilz-postgres --format '{{.Config.Image}}'
 ```
 
 ### Check Service Health

--- a/deploy/docker-compose/docker-compose.ai.yml
+++ b/deploy/docker-compose/docker-compose.ai.yml
@@ -115,6 +115,12 @@ services:
       #   AI_FALLBACK_CHAIN=google:gemini-3.6-flash,anthropic:claude-haiku-4-5,openai:gpt-4o-mini
       AI_FALLBACK_ENABLED: ${AI_FALLBACK_ENABLED:-false}
       AI_FALLBACK_CHAIN: ${AI_FALLBACK_CHAIN:-}
+      # Extra API keys per provider (comma-separated, tried in order). Quota is charged per
+      # key, so a provider rotates to its next key once every chain model is spent on the
+      # current one. Leave empty to keep using the single key above.
+      AI_FALLBACK_KEYS_GOOGLE: ${AI_FALLBACK_KEYS_GOOGLE:-}
+      AI_FALLBACK_KEYS_ANTHROPIC: ${AI_FALLBACK_KEYS_ANTHROPIC:-}
+      AI_FALLBACK_KEYS_OPENAI: ${AI_FALLBACK_KEYS_OPENAI:-}
       AI_FALLBACK_QUOTA_COOLDOWN: ${AI_FALLBACK_QUOTA_COOLDOWN:-5m}
       AI_FALLBACK_UNAVAILABLE_COOLDOWN: ${AI_FALLBACK_UNAVAILABLE_COOLDOWN:-6h}
 

--- a/deploy/docker-compose/docker-compose.ai.yml
+++ b/deploy/docker-compose/docker-compose.ai.yml
@@ -107,7 +107,16 @@ services:
       # Google Gemini (chat only — embeddings stay on Ollama/OpenAI)
       GOOGLE_API_KEY: ${GOOGLE_API_KEY:-}
       GOOGLE_CHAT_ENABLED: ${GOOGLE_CHAT_ENABLED:-false}
-      GOOGLE_CHAT_MODEL: ${GOOGLE_CHAT_MODEL:-gemini-2.5-flash}
+      GOOGLE_CHAT_MODEL: ${GOOGLE_CHAT_MODEL:-gemini-3.6-flash}
+
+      # Automatic failover when the active chat model is out of quota, retired, or unreachable.
+      # Chain entries are 'provider:model' (google|anthropic|openai|openai-compatible), tried in
+      # order; each needs its API key above. Useful on free tiers, whose allowances run out fast.
+      #   AI_FALLBACK_CHAIN=google:gemini-3.6-flash,anthropic:claude-haiku-4-5,openai:gpt-4o-mini
+      AI_FALLBACK_ENABLED: ${AI_FALLBACK_ENABLED:-false}
+      AI_FALLBACK_CHAIN: ${AI_FALLBACK_CHAIN:-}
+      AI_FALLBACK_QUOTA_COOLDOWN: ${AI_FALLBACK_QUOTA_COOLDOWN:-5m}
+      AI_FALLBACK_UNAVAILABLE_COOLDOWN: ${AI_FALLBACK_UNAVAILABLE_COOLDOWN:-6h}
 
       # Per-user AI settings (BYOK) — needs an encryption key: openssl rand -base64 32
       AI_USER_SETTINGS_ENABLED: ${AI_USER_SETTINGS_ENABLED:-false}

--- a/deploy/docker-compose/docker-compose.ai.yml
+++ b/deploy/docker-compose/docker-compose.ai.yml
@@ -10,13 +10,23 @@
 #
 # For OpenAI instead of Ollama, skip this overlay and set the OPENAI_*
 # variables in .env along with OPENFILZ_AI_ACTIVE=true.
+#
+# NOTE: this intentionally reads POSTGRES_AI_IMAGE, not POSTGRES_IMAGE — if it
+# reused POSTGRES_IMAGE, a value already pinned in .env for the base (non-AI)
+# deployment (e.g. POSTGRES_IMAGE=postgres:17) would silently defeat this
+# override and postgres would come up without the vector extension, failing
+# Flyway's V1_4__add_ai_support.sql with "extension \"vector\" is not
+# available". If you're enabling AI on a deployment that was already running
+# without it, this override still applies on `docker-compose ... up -d` —
+# compose recreates the postgres container in place (same volume, no data
+# loss) once it sees the image changed.
 
 services:
   # =============================================================================
   # PostgreSQL — override to pgvector-enabled image
   # =============================================================================
   postgres:
-    image: ${POSTGRES_IMAGE:-pgvector/pgvector:pg17}
+    image: ${POSTGRES_AI_IMAGE:-pgvector/pgvector:pg17}
 
   # =============================================================================
   # Ollama LLM Server (local AI inference)

--- a/deploy/docker-compose/dokploy/.env.example
+++ b/deploy/docker-compose/dokploy/.env.example
@@ -15,7 +15,12 @@ ONLYOFFICE_HOSTNAME=docs.yourdomain.com
 # =============================================================================
 # Database Configuration
 # =============================================================================
-POSTGRES_IMAGE=postgres:16
+# compose.yaml already defaults this to pgvector/pgvector:pg17 (a pgvector-enabled
+# postgres:17), which is required for AI Document Chat (OPENFILZ_AI_ACTIVE=true).
+# Leave commented out unless you need to pin something else — setting this to a
+# plain postgres image (e.g. postgres:16) silently disables AI: Flyway's
+# V1_4__add_ai_support.sql then fails with "extension \"vector\" is not available".
+#POSTGRES_IMAGE=pgvector/pgvector:pg17
 DB_NAME=dms_db
 DB_USER=dms_user
 DB_PASSWORD=change-this-strong-password

--- a/deploy/docker-compose/dokploy/.env.example
+++ b/deploy/docker-compose/dokploy/.env.example
@@ -119,3 +119,38 @@ ONLYOFFICE_URL=http://onlyoffice
 # =============================================================================
 # Storage type: local (default) - MinIO not included in this Dokploy setup
 STORAGE_TYPE=local
+
+# =============================================================================
+# AI Document Chat (optional)
+# =============================================================================
+# Uncomment to enable. Requires POSTGRES_IMAGE above to stay pgvector-enabled
+# (it does by default) — Flyway's AI migration needs the `vector` extension.
+#OPENFILZ_AI_ACTIVE=true
+
+# --- Local inference via Ollama (self-hosted, no API key needed) ---
+# IMPORTANT: compose.yaml activates the ollama/ollama-init services with a
+# profile-name-is-the-boolean trick (profiles: ["${OLLAMA_CHAT_ENABLED:-false}", ...]).
+# Docker Compose only starts services whose profile is listed in COMPOSE_PROFILES,
+# so this variable MUST also be set to "true" — without it, OLLAMA_CHAT_ENABLED/
+# OLLAMA_EMBEDDING_ENABLED alone will NOT create the ollama container, and
+# openfilz-api will fail to reach it ("ollama: Temporary failure in name
+# resolution") even though AI itself is active.
+#COMPOSE_PROFILES=true
+#OLLAMA_CHAT_ENABLED=true
+#OLLAMA_CHAT_MODEL=llama3
+#OLLAMA_EMBEDDING_ENABLED=true
+#OLLAMA_EMBEDDING_MODEL=nomic-embed-text
+
+# --- Or use a hosted provider instead of/alongside Ollama (no COMPOSE_PROFILES needed) ---
+#OPENAI_API_KEY=
+#OPENAI_CHAT_ENABLED=true
+#OPENAI_EMBEDDING_ENABLED=true
+#ANTHROPIC_API_KEY=
+#ANTHROPIC_CHAT_ENABLED=true
+#GOOGLE_API_KEY=
+#GOOGLE_CHAT_ENABLED=true
+
+# --- Per-user AI settings (BYOK) ---
+#AI_USER_SETTINGS_ENABLED=true
+# Generate with: openssl rand -base64 32
+#AI_SETTINGS_ENCRYPTION_KEY=

--- a/deploy/docker-compose/dokploy/.env.example
+++ b/deploy/docker-compose/dokploy/.env.example
@@ -163,6 +163,13 @@ STORAGE_TYPE=local
 # each needs its API key set above. The active model is tried first and needs no entry.
 #AI_FALLBACK_ENABLED=true
 #AI_FALLBACK_CHAIN=google:gemini-3.6-flash,anthropic:claude-haiku-4-5,openai:gpt-4o-mini
+# Several keys per provider, comma-separated and tried in order. Quota is charged per KEY, so
+# once every chain model of a provider is spent on the key in use, the next key of that provider
+# takes over and those models work again — the cheapest way to widen a free-tier allowance.
+# A provider left empty here keeps using its single API key above.
+#AI_FALLBACK_KEYS_GOOGLE=AIza-first-project-key,AIza-second-project-key
+#AI_FALLBACK_KEYS_ANTHROPIC=
+#AI_FALLBACK_KEYS_OPENAI=
 # How long a model is benched after a spent quota / outage (per-minute limits refill fast).
 #AI_FALLBACK_QUOTA_COOLDOWN=5m
 # How long after a 404 — longer, because a retired model will not come back on its own.

--- a/deploy/docker-compose/dokploy/.env.example
+++ b/deploy/docker-compose/dokploy/.env.example
@@ -149,6 +149,24 @@ STORAGE_TYPE=local
 #ANTHROPIC_CHAT_ENABLED=true
 #GOOGLE_API_KEY=
 #GOOGLE_CHAT_ENABLED=true
+# Pin the model explicitly — providers retire model ids, and a retired one fails every chat
+# with a 404 ("no longer available to new users") until this is updated.
+#GOOGLE_CHAT_MODEL=gemini-3.6-flash
+
+# --- Automatic failover between chat models ---
+# Free tiers hand out small per-minute/per-day allowances. With this on, a chat that fails
+# because the quota is spent (or the model was retired, or the provider is down) is retried
+# on the next model in the chain, and the failed model is benched for a cooldown so the
+# requests after it skip straight to one that works. A bad API key never triggers failover —
+# that surfaces as an error so you fix the key rather than silently answering elsewhere.
+# Entries are 'provider:model' (google|anthropic|openai|openai-compatible), tried in order;
+# each needs its API key set above. The active model is tried first and needs no entry.
+#AI_FALLBACK_ENABLED=true
+#AI_FALLBACK_CHAIN=google:gemini-3.6-flash,anthropic:claude-haiku-4-5,openai:gpt-4o-mini
+# How long a model is benched after a spent quota / outage (per-minute limits refill fast).
+#AI_FALLBACK_QUOTA_COOLDOWN=5m
+# How long after a 404 — longer, because a retired model will not come back on its own.
+#AI_FALLBACK_UNAVAILABLE_COOLDOWN=6h
 
 # --- Per-user AI settings (BYOK) ---
 #AI_USER_SETTINGS_ENABLED=true

--- a/deploy/docker-compose/dokploy/compose.yaml
+++ b/deploy/docker-compose/dokploy/compose.yaml
@@ -234,7 +234,13 @@ services:
       ANTHROPIC_CHAT_MODEL: ${ANTHROPIC_CHAT_MODEL:-claude-opus-5}
       GOOGLE_API_KEY: ${GOOGLE_API_KEY:-}
       GOOGLE_CHAT_ENABLED: ${GOOGLE_CHAT_ENABLED:-false}
-      GOOGLE_CHAT_MODEL: ${GOOGLE_CHAT_MODEL:-gemini-2.5-flash}
+      GOOGLE_CHAT_MODEL: ${GOOGLE_CHAT_MODEL:-gemini-3.6-flash}
+      # Automatic failover when the active chat model is out of quota, retired, or unreachable
+      # (see openfilz.ai.fallback). Chain entries are 'provider:model', tried in order.
+      AI_FALLBACK_ENABLED: ${AI_FALLBACK_ENABLED:-false}
+      AI_FALLBACK_CHAIN: ${AI_FALLBACK_CHAIN:-}
+      AI_FALLBACK_QUOTA_COOLDOWN: ${AI_FALLBACK_QUOTA_COOLDOWN:-5m}
+      AI_FALLBACK_UNAVAILABLE_COOLDOWN: ${AI_FALLBACK_UNAVAILABLE_COOLDOWN:-6h}
       # Per-user AI settings (BYOK) — needs an encryption key: openssl rand -base64 32
       AI_USER_SETTINGS_ENABLED: ${AI_USER_SETTINGS_ENABLED:-false}
       AI_SETTINGS_ENCRYPTION_KEY: ${AI_SETTINGS_ENCRYPTION_KEY:-}

--- a/deploy/docker-compose/dokploy/compose.yaml
+++ b/deploy/docker-compose/dokploy/compose.yaml
@@ -239,6 +239,12 @@ services:
       # (see openfilz.ai.fallback). Chain entries are 'provider:model', tried in order.
       AI_FALLBACK_ENABLED: ${AI_FALLBACK_ENABLED:-false}
       AI_FALLBACK_CHAIN: ${AI_FALLBACK_CHAIN:-}
+      # Extra API keys per provider (comma-separated, tried in order). Quota is charged per
+      # key, so a provider rotates to its next key once every chain model is spent on the
+      # current one. Leave empty to keep using the single key above.
+      AI_FALLBACK_KEYS_GOOGLE: ${AI_FALLBACK_KEYS_GOOGLE:-}
+      AI_FALLBACK_KEYS_ANTHROPIC: ${AI_FALLBACK_KEYS_ANTHROPIC:-}
+      AI_FALLBACK_KEYS_OPENAI: ${AI_FALLBACK_KEYS_OPENAI:-}
       AI_FALLBACK_QUOTA_COOLDOWN: ${AI_FALLBACK_QUOTA_COOLDOWN:-5m}
       AI_FALLBACK_UNAVAILABLE_COOLDOWN: ${AI_FALLBACK_UNAVAILABLE_COOLDOWN:-6h}
       # Per-user AI settings (BYOK) — needs an encryption key: openssl rand -base64 32

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -544,9 +544,55 @@ Anthropic has no embeddings API — pair it with Ollama or OpenAI embeddings (e.
 |--------------------------|---------|-------------|
 | `spring.ai.google.genai.api-key` / `GOOGLE_API_KEY` | *(empty)* | API key from Google AI Studio (required when using Gemini) |
 | `openfilz.ai.google.chat.enabled` / `GOOGLE_CHAT_ENABLED` | `false` | Enable Gemini as the chat model provider |
-| `spring.ai.google.genai.chat.model` / `GOOGLE_CHAT_MODEL` | `gemini-2.5-flash` | Chat model name (`gemini-2.5-pro` for higher quality) |
+| `spring.ai.google.genai.chat.model` / `GOOGLE_CHAT_MODEL` | `gemini-3.6-flash` | Chat model name |
 
 Uses the Gemini Developer API (API-key auth, not Vertex AI). In OpenFilz, Gemini serves chat only — embeddings stay on Ollama/OpenAI so the pgvector schema keeps its 768 dimensions.
+
+> **Model ids get retired.** Google withdraws older ids, after which *every* chat fails with
+> `404 … This model models/<id> is no longer available to new users`. The fix is to update
+> `GOOGLE_CHAT_MODEL` (the error message names the replacement). Configuring
+> [model failover](#ai-model-failover-quota-and-availability) below keeps chat working while
+> you do.
+
+#### AI model failover (quota and availability)
+
+Free tiers allow only a handful of requests per minute and per day. When the configured model
+refuses — quota spent, model retired, provider down — OpenFilz can retry the same question on
+another model instead of failing the user.
+
+| Property / Env Variable | Default | Description |
+|--------------------------|---------|-------------|
+| `openfilz.ai.fallback.enabled` / `AI_FALLBACK_ENABLED` | `false` | Enable automatic failover to another chat model |
+| `openfilz.ai.fallback.chain` / `AI_FALLBACK_CHAIN` | *(empty)* | Comma-separated `provider:model` entries, tried in order (`google`, `anthropic`, `openai`, `openai-compatible`) |
+| `openfilz.ai.fallback.quota-cooldown` / `AI_FALLBACK_QUOTA_COOLDOWN` | `5m` | How long a model is skipped after a spent quota or a provider outage |
+| `openfilz.ai.fallback.unavailable-cooldown` / `AI_FALLBACK_UNAVAILABLE_COOLDOWN` | `6h` | How long a model is skipped after a `404` (retired / not enabled for the key) |
+
+```
+AI_FALLBACK_ENABLED=true
+AI_FALLBACK_CHAIN=google:gemini-3.6-flash,anthropic:claude-haiku-4-5,openai:gpt-4o-mini
+```
+
+Each provider in the chain needs its own API key configured above; entries without one are
+skipped with a warning. The active chat model is always tried first and needs no entry.
+
+Two things happen on a failure. The request itself is **retried** on the next model, so the user
+still gets an answer. The failed model is then **benched** for its cooldown, so the requests that
+follow skip it rather than each paying the same failing call first — which is what stops a spent
+*daily* quota from slowing every request for the rest of the day. Cooldowns expire on their own;
+nothing needs restarting.
+
+Watch for these in the logs:
+
+```
+[AI] QUOTA_EXHAUSTED on google-genai (gemini-3.6-flash) — falling back to ANTHROPIC (claude-haiku-4-5)
+[AI-FALLBACK] QUOTA_EXHAUSTED on google:gemini-3.6-flash — benching it for PT5M
+```
+
+> **A bad API key never triggers failover.** Quietly answering from a different model would hide a
+> broken credential instead of surfacing it, so authentication and malformed-request errors are
+> still returned as errors. Failover is also abandoned if the model already streamed part of an
+> answer, or if a tool already moved/renamed/deleted something — retrying either would show the
+> user a spliced answer or repeat the action.
 
 #### Getting an API key
 

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -564,6 +564,7 @@ another model instead of failing the user.
 |--------------------------|---------|-------------|
 | `openfilz.ai.fallback.enabled` / `AI_FALLBACK_ENABLED` | `false` | Enable automatic failover to another chat model |
 | `openfilz.ai.fallback.chain` / `AI_FALLBACK_CHAIN` | *(empty)* | Comma-separated `provider:model` entries, tried in order (`google`, `anthropic`, `openai`, `openai-compatible`) |
+| `openfilz.ai.fallback.keys.<provider>` / `AI_FALLBACK_KEYS_GOOGLE`, `..._ANTHROPIC`, `..._OPENAI` | *(empty)* | Comma-separated pool of API keys for that provider, tried in order. Empty means "keep using the single key above" |
 | `openfilz.ai.fallback.quota-cooldown` / `AI_FALLBACK_QUOTA_COOLDOWN` | `5m` | How long a model is skipped after a spent quota or a provider outage |
 | `openfilz.ai.fallback.unavailable-cooldown` / `AI_FALLBACK_UNAVAILABLE_COOLDOWN` | `6h` | How long a model is skipped after a `404` (retired / not enabled for the key) |
 
@@ -574,6 +575,21 @@ AI_FALLBACK_CHAIN=google:gemini-3.6-flash,anthropic:claude-haiku-4-5,openai:gpt-
 
 Each provider in the chain needs its own API key configured above; entries without one are
 skipped with a warning. The active chat model is always tried first and needs no entry.
+
+**Several keys per provider.** Quota is charged per API key, so a second key is a second
+allowance — the cheapest way to widen a free tier:
+
+```
+AI_FALLBACK_KEYS_GOOGLE=AIza-first-project-key,AIza-second-project-key
+```
+
+A provider is exhausted completely before the next one is used: every chain model on the first
+key, then every chain model on the second, and only then does the chain move to another provider
+— which of course uses that provider's own keys. A single spent model does not cost you the key;
+the provider's other models keep using it. Leave a provider's pool empty to keep its single key.
+
+Keys never appear in logs: each is identified by a short fingerprint (`a1b2c3d4`), which is also
+what keeps two BYOK users on the same model from sharing a cooldown.
 
 Two things happen on a failure. The request itself is **retried** on the next model, so the user
 still gets an answer. The failed model is then **benched** for its cooldown, so the requests that

--- a/docs/ai.md
+++ b/docs/ai.md
@@ -292,11 +292,80 @@ Security properties:
 
 ---
 
+## 5b. Quota failover between chat models
+
+Free provider tiers (Google's especially) allow only a small number of requests per minute and
+per day, so a busy afternoon can exhaust the configured model. With
+`openfilz.ai.fallback.enabled=true` the chat pipeline retries the same question on the next model
+in `openfilz.ai.fallback.chain` instead of failing the user.
+
+```
+AI_FALLBACK_ENABLED=true
+AI_FALLBACK_CHAIN=google:gemini-3.6-flash,anthropic:claude-haiku-4-5,openai:gpt-4o-mini
+```
+
+Two mechanisms, and both matter:
+
+| Mechanism | What it does | Where |
+|---|---|---|
+| **Failover** | The request that hit the quota is retried on the next candidate, so the user still gets an answer. | `AiChatServiceImpl#streamWithFailover` |
+| **Cooldown** | The failed model is benched, so *subsequent* requests skip it instead of each paying a failing round-trip first. Cooldowns expire on their own, returning the model to rotation with no operator action. | `AiFallbackChain` |
+
+Without the cooldown, a spent **daily** quota would add a failing call to every request for the
+rest of the day; with it, the deployment pays that cost once.
+
+### What counts as a failover
+
+`AiFailoverPolicy.classify` walks the cause chain — Spring AI wraps every provider failure in a
+generic `RuntimeException("Failed to generate content")`, so the actionable signal is always
+further down — and matches on HTTP status, exception type name, and message keywords. No provider
+SDK types are referenced: OpenFilz must not compile against (nor reflect over, which GraalVM
+dislikes) `com.google.genai.errors.*` and friends.
+
+| Classification | Trigger | Cooldown |
+|---|---|---|
+| `QUOTA_EXHAUSTED` | 429 / `RESOURCE_EXHAUSTED` / rate-limit wording / typed `RateLimitException` | `quota-cooldown` (5m) |
+| `MODEL_UNAVAILABLE` | 404 — model retired, renamed, or not enabled for the key | `unavailable-cooldown` (6h) |
+| `PROVIDER_OVERLOADED` | 5xx, connection refused, unknown host, timeouts | `quota-cooldown` (5m) |
+| `NOT_FAILOVER` | **bad credentials**, malformed requests, OpenFilz bugs | none |
+
+Credential failures deliberately do *not* fail over. Answering from a different model when an API
+key is wrong or revoked would hide a misconfiguration an operator has to fix; those still surface
+as errors. A retired model gets the long cooldown because — unlike a quota — it is never coming
+back on its own.
+
+### When a retry is refused
+
+Failover is abandoned mid-request, and the error propagates, when either guard trips:
+
+- **Tokens already streamed.** Restarting on another model would splice two different answers
+  together in the user's browser.
+- **A tool already mutated something.** Read-only tools are safe to repeat; retrying after a
+  move/rename/delete would run it twice. `DocumentAiTools#getModifiedFolders` is empty exactly
+  when no mutating tool has fired this turn.
+
+In practice quota and 404 failures arrive before the first token, so both guards hold.
+
+### Scope
+
+Chain entries are limited to the API-key providers OpenFilz already builds programmatically
+(`google`, `anthropic`, `openai`, `openai-compatible`) — the same `buildChatModel` path BYOK uses.
+Ollama is deliberately absent: it is local, has no quota to exhaust, and its model comes from
+Spring AI auto-configuration rather than being built by hand. Entries whose provider has no
+server API key configured are skipped with a warning rather than failing the request.
+
+Cooldown state is per-instance and in-memory — a latency optimisation, not a correctness
+mechanism. A restart (or a second replica) simply costs one failed call per model before it
+re-learns.
+
+---
+
 ## 6. Where to look in the code
 
 | Area | Entry point |
 |---|---|
 | Selector derivation | `config/AiModelProviderEnvironmentPostProcessor` |
+| Quota failover / cooldowns | `service/ai/AiFallbackChain`, `service/ai/AiFailoverPolicy` |
 | Beans (DataSource, PgVectorStore) | `config/AiConfig` |
 | Embedding-change guard | `config/EmbeddingRegistryGuard` |
 | Ingestion fan-out | `service/impl/DefaultMetadataPostProcessor` |

--- a/docs/ai.md
+++ b/docs/ai.md
@@ -302,6 +302,7 @@ in `openfilz.ai.fallback.chain` instead of failing the user.
 ```
 AI_FALLBACK_ENABLED=true
 AI_FALLBACK_CHAIN=google:gemini-3.6-flash,anthropic:claude-haiku-4-5,openai:gpt-4o-mini
+AI_FALLBACK_KEYS_GOOGLE=AIza-first-project,AIza-second-project
 ```
 
 Two mechanisms, and both matter:
@@ -313,6 +314,36 @@ Two mechanisms, and both matter:
 
 Without the cooldown, a spent **daily** quota would add a failing call to every request for the
 rest of the day; with it, the deployment pays that cost once.
+
+### Key pools and rotation
+
+Quota is charged **per API key**, per model — so a second key is a second allowance, and
+`openfilz.ai.fallback.keys.<provider>` gives each provider an ordered pool. A provider with no
+pool keeps using its single `spring.ai.*.api-key`, so existing deployments are unaffected.
+
+Candidates are laid out so that a provider is exhausted completely — every chain model on every
+key — before the next provider is touched:
+
+```
+google:     m1/keyA   m2/keyA   m1/keyB   m2/keyB
+anthropic:  c1/keyX   c1/keyY
+```
+
+The key therefore rotates as soon as the provider has nothing left on the current one, and a
+different provider is only reached once the previous one is spent outright. Chain order decides
+*provider* priority (by first appearance) and model priority within a provider; an interleaved
+chain like `google:m1,anthropic:c1,google:m2` is grouped as `google:m1,google:m2` then
+`anthropic:c1`, because key rotation is inherently a per-provider decision.
+
+Which key is "current" is **derived** from the cooldown registry rather than held in a pointer: a
+provider's usable keys are those with at least one chain model still healthy. A key spent an hour
+ago drops out of the list and rejoins it when its cooldowns lapse — no stored index to get stuck.
+A single spent *model* does not cost you the key: the other models keep using it, and only that
+model moves on.
+
+Keys are never held in cooldown maps, cache keys or logs. `AiKeyRef` reduces each to an 8-hex-char
+SHA-256 fingerprint, which is enough to tell keys apart and useless to anyone reading a log — and
+it is what keeps two BYOK users on the same provider and model from sharing a cooldown bucket.
 
 ### What counts as a failover
 
@@ -366,6 +397,7 @@ re-learns.
 |---|---|
 | Selector derivation | `config/AiModelProviderEnvironmentPostProcessor` |
 | Quota failover / cooldowns | `service/ai/AiFallbackChain`, `service/ai/AiFailoverPolicy` |
+| API-key fingerprints | `service/ai/AiKeyRef` |
 | Beans (DataSource, PgVectorStore) | `config/AiConfig` |
 | Embedding-change guard | `config/EmbeddingRegistryGuard` |
 | Ingestion fan-out | `service/impl/DefaultMetadataPostProcessor` |

--- a/openfilz-api/src/main/java/org/openfilz/dms/config/AiProperties.java
+++ b/openfilz-api/src/main/java/org/openfilz/dms/config/AiProperties.java
@@ -4,6 +4,10 @@ import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Configuration properties for the AI document chat feature.
  * Maps to openfilz.ai.* properties in application.yml.
@@ -39,6 +43,11 @@ public class AiProperties {
      * Embedding configuration.
      */
     private EmbeddingConfig embedding = new EmbeddingConfig();
+
+    /**
+     * Automatic failover to another chat model when the configured one runs out of quota.
+     */
+    private Fallback fallback = new Fallback();
 
     /**
      * Ollama provider switches.
@@ -83,6 +92,49 @@ public class AiProperties {
              */
             private boolean enabled = false;
         }
+    }
+
+    /**
+     * Chat-model failover: what to try when the configured model refuses to answer.
+     * <p>
+     * Aimed squarely at free provider tiers, whose per-minute and per-day allowances are small
+     * enough to hit during normal use. When a chat call fails with an exhausted quota, a retired
+     * model, or an unreachable provider, OpenFilz retries the same question on the next model in
+     * {@link #chain} and benches the failed one for a cooldown so later requests skip it outright.
+     * See {@code AiFallbackChain} and {@code AiFailoverPolicy}.
+     * <p>
+     * A credential failure never triggers failover — answering from a different model would hide
+     * a broken API key instead of surfacing it.
+     */
+    @Data
+    public static class Fallback {
+
+        /** Master switch; off by default so existing deployments behave exactly as before. */
+        private boolean enabled = false;
+
+        /**
+         * Models to fall back to, in order, as {@code provider:model} entries — for example
+         * {@code google:gemini-3.6-flash,anthropic:claude-haiku-4-5,openai:gpt-4o-mini}.
+         * Providers: {@code google}, {@code anthropic}, {@code openai}, {@code openai-compatible};
+         * each needs its server API key configured, and entries without one are skipped with a
+         * warning. The active chat model is always tried first and needs no entry here.
+         */
+        private List<String> chain = new ArrayList<>();
+
+        /**
+         * How long a model is benched after an exhausted quota, an overloaded provider, or a
+         * connection failure. Short by design: per-minute allowances refill quickly, and an
+         * expired cooldown silently returns the model to rotation.
+         */
+        private Duration quotaCooldown = Duration.ofMinutes(5);
+
+        /**
+         * How long a model is benched after a 404 (retired, renamed, or not enabled for this key).
+         * Much longer than {@link #quotaCooldown} because that model is not coming back on its
+         * own — the cooldown just stops every request paying for the same 404 until an operator
+         * updates the configuration.
+         */
+        private Duration unavailableCooldown = Duration.ofHours(6);
     }
 
     /**

--- a/openfilz-api/src/main/java/org/openfilz/dms/config/AiProperties.java
+++ b/openfilz-api/src/main/java/org/openfilz/dms/config/AiProperties.java
@@ -4,9 +4,13 @@ import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
+import org.openfilz.dms.enums.AiProvider;
+
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Configuration properties for the AI document chat feature.
@@ -120,6 +124,19 @@ public class AiProperties {
          * warning. The active chat model is always tried first and needs no entry here.
          */
         private List<String> chain = new ArrayList<>();
+
+        /**
+         * Additional API keys per provider, tried in order — the answer to a free tier whose
+         * quota is charged <em>per key</em> rather than per model.
+         * <p>
+         * Once every {@link #chain} model for a provider is out of quota on the key in use, the
+         * next key in that provider's pool takes over and those models are available again. Each
+         * provider keeps its own pool, so a chain that mixes providers always reaches for the key
+         * belonging to whichever provider it lands on.
+         * <p>
+         * Leave a provider's pool empty to keep using its single {@code spring.ai.*.api-key}.
+         */
+        private Map<AiProvider, List<String>> keys = new LinkedHashMap<>();
 
         /**
          * How long a model is benched after an exhausted quota, an overloaded provider, or a

--- a/openfilz-api/src/main/java/org/openfilz/dms/service/ai/AiFailoverPolicy.java
+++ b/openfilz-api/src/main/java/org/openfilz/dms/service/ai/AiFailoverPolicy.java
@@ -1,0 +1,192 @@
+package org.openfilz.dms.service.ai;
+
+import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Classifies a chat-model failure to decide whether OpenFilz may transparently fail over to
+ * the next model in the fallback chain (see {@link AiFallbackChain}).
+ * <p>
+ * Deliberately dependency-free: each provider SDK reports quota and availability differently
+ * (Google GenAI throws {@code com.google.genai.errors.ClientException} carrying an HTTP status
+ * in its message, the Anthropic and OpenAI SDKs throw typed {@code RateLimitException}s, Spring
+ * AI wraps all of them in a generic {@code RuntimeException("Failed to generate content")}), and
+ * OpenFilz must not compile against — nor reflect over, which GraalVM native images dislike —
+ * any of those types. So classification walks the cause chain and matches on HTTP status,
+ * exception simple name, and message keywords only.
+ * <p>
+ * The one failure kind that deliberately does <em>not</em> fail over is a credential problem:
+ * silently answering with a different model when an API key is wrong or revoked would hide a
+ * misconfiguration that an operator has to fix. Those surface to the caller as before.
+ */
+public final class AiFailoverPolicy {
+
+    private AiFailoverPolicy() {
+    }
+
+    /** What went wrong, and whether another model is worth trying. */
+    public enum Failure {
+
+        /** 429 / RESOURCE_EXHAUSTED — the per-minute or per-day quota is spent. Retry elsewhere. */
+        QUOTA_EXHAUSTED(true),
+
+        /** 404 — the model was retired, renamed, or is not enabled for this key. Retry elsewhere. */
+        MODEL_UNAVAILABLE(true),
+
+        /** 5xx, connection failures, timeouts — the provider is down or unreachable. Retry elsewhere. */
+        PROVIDER_OVERLOADED(true),
+
+        /** Bad credentials, malformed request, or an OpenFilz bug — surface it, never mask it. */
+        NOT_FAILOVER(false);
+
+        private final boolean failover;
+
+        Failure(boolean failover) {
+            this.failover = failover;
+        }
+
+        /** Whether OpenFilz should try the next model in the chain for this failure. */
+        public boolean shouldFailover() {
+            return failover;
+        }
+    }
+
+    /** Guards against a pathological (or cyclic) cause chain. */
+    private static final int MAX_CAUSE_DEPTH = 12;
+
+    /** HTTP statuses we recognise; anything else parsed out of a message is ignored as noise. */
+    private static final Set<Integer> KNOWN_STATUSES = Set.of(
+            400, 401, 402, 403, 404, 408, 409, 413, 422, 425, 429, 500, 502, 503, 504, 529);
+
+    /**
+     * Status at the very start of the message — the shape the Google GenAI SDK uses
+     * ({@code "404 . This model models/gemini-2.5-flash is no longer available…"}).
+     */
+    private static final Pattern LEADING_STATUS = Pattern.compile("^\\s*(\\d{3})\\b");
+
+    /** Status introduced by a label, e.g. {@code "status code: 429"} or {@code "HTTP 503"}. */
+    private static final Pattern LABELLED_STATUS =
+            Pattern.compile("(?:status|code|http)\\D{0,10}?(\\d{3})\\b", Pattern.CASE_INSENSITIVE);
+
+    private static final String[] QUOTA_KEYWORDS = {
+            "resource_exhausted", "resource exhausted", "rate limit", "rate_limit", "ratelimit",
+            "too many requests", "quota", "exceeded your current", "billing hard limit",
+            "insufficient_quota", "requests per minute", "requests per day"
+    };
+
+    private static final String[] MODEL_GONE_KEYWORDS = {
+            "no longer available", "not available", "not found", "does not exist", "unknown model",
+            "model_not_found", "invalid model", "unsupported model", "is not supported",
+            "not found for api version", "deprecated"
+    };
+
+    private static final String[] AUTH_KEYWORDS = {
+            "api key", "api_key", "apikey", "unauthenticated", "unauthorized", "permission_denied",
+            "permission denied", "invalid authentication", "invalid_authentication", "credential",
+            "authentication_error", "forbidden", "access denied"
+    };
+
+    private static final String[] OVERLOAD_KEYWORDS = {
+            "overloaded", "service unavailable", "service_unavailable", "unavailable",
+            "try again later", "temporarily", "internal error", "internal server error",
+            "backend error", "bad gateway", "deadline exceeded", "timed out", "timeout",
+            "connection reset", "connection refused", "temporary failure in name resolution"
+    };
+
+    /** Exception simple names (substring match) that identify a failure without parsing the message. */
+    private static final String[] QUOTA_TYPES = {"RateLimit", "ResourceExhausted", "TooManyRequests", "Quota"};
+    private static final String[] MODEL_GONE_TYPES = {"NotFound", "ModelNotFound"};
+    private static final String[] AUTH_TYPES = {"Authentication", "PermissionDenied", "Unauthorized", "Forbidden"};
+    private static final String[] OVERLOAD_TYPES = {
+            "Overloaded", "ServiceUnavailable", "ServerException", "InternalServer",
+            "UnknownHost", "ConnectException", "SocketTimeout", "Timeout", "ConnectTimeout"
+    };
+
+    /**
+     * Classify a failure thrown by (or wrapped around) a chat-model call.
+     * <p>
+     * The whole cause chain is inspected because Spring AI wraps provider exceptions in a
+     * generic {@code RuntimeException}: the actionable signal is always further down. The first
+     * cause that yields a verdict other than {@link Failure#NOT_FAILOVER} wins, so a definite
+     * "429" deep in the chain is not masked by an uninformative wrapper at the top.
+     */
+    public static Failure classify(Throwable error) {
+        Failure verdict = Failure.NOT_FAILOVER;
+        Throwable current = error;
+        for (int depth = 0; current != null && depth < MAX_CAUSE_DEPTH; depth++) {
+            Failure found = classifySingle(current);
+            if (found != Failure.NOT_FAILOVER) {
+                verdict = found;
+                break;
+            }
+            Throwable cause = current.getCause();
+            current = (cause == current) ? null : cause;
+        }
+        return verdict;
+    }
+
+    /** Classify one link of the cause chain, ignoring its causes. */
+    private static Failure classifySingle(Throwable error) {
+        String type = error.getClass().getSimpleName();
+        String message = error.getMessage() == null ? "" : error.getMessage().toLowerCase(Locale.ROOT);
+
+        // Typed exceptions are unambiguous — prefer them over message archaeology.
+        if (containsAny(type, QUOTA_TYPES)) return Failure.QUOTA_EXHAUSTED;
+        if (containsAny(type, AUTH_TYPES)) return Failure.NOT_FAILOVER;
+        if (containsAny(type, MODEL_GONE_TYPES)) return Failure.MODEL_UNAVAILABLE;
+        if (containsAny(type, OVERLOAD_TYPES)) return Failure.PROVIDER_OVERLOADED;
+
+        Integer status = extractStatus(message);
+        if (status != null) {
+            return switch (status) {
+                case 429 -> Failure.QUOTA_EXHAUSTED;
+                // Some providers report an exhausted quota as 402/403 rather than 429, so the
+                // message still decides; without quota wording these stay a credential problem.
+                case 401, 402, 403 -> containsAny(message, QUOTA_KEYWORDS)
+                        ? Failure.QUOTA_EXHAUSTED : Failure.NOT_FAILOVER;
+                case 404 -> Failure.MODEL_UNAVAILABLE;
+                case 408, 500, 502, 503, 504, 529 -> Failure.PROVIDER_OVERLOADED;
+                // Any other recognised status is a request we built wrong — our bug, not the
+                // model's; another model would fail identically, so do not burn the chain on it.
+                default -> Failure.NOT_FAILOVER;
+            };
+        }
+
+        if (containsAny(message, QUOTA_KEYWORDS)) return Failure.QUOTA_EXHAUSTED;
+        if (containsAny(message, AUTH_KEYWORDS)) return Failure.NOT_FAILOVER;
+        if (containsAny(message, MODEL_GONE_KEYWORDS)) return Failure.MODEL_UNAVAILABLE;
+        if (containsAny(message, OVERLOAD_KEYWORDS)) return Failure.PROVIDER_OVERLOADED;
+        return Failure.NOT_FAILOVER;
+    }
+
+    /**
+     * Pull an HTTP status out of a message, without guessing.
+     * <p>
+     * Only a leading status or an explicitly labelled one counts: a bare three-digit scan would
+     * happily read "429" out of a model name or a token count and fail over for no reason.
+     */
+    private static Integer extractStatus(String message) {
+        Integer leading = firstMatch(LEADING_STATUS, message);
+        if (leading != null) return leading;
+        return firstMatch(LABELLED_STATUS, message);
+    }
+
+    private static Integer firstMatch(Pattern pattern, String message) {
+        Matcher matcher = pattern.matcher(message);
+        while (matcher.find()) {
+            int value = Integer.parseInt(matcher.group(1));
+            if (KNOWN_STATUSES.contains(value)) return value;
+        }
+        return null;
+    }
+
+    private static boolean containsAny(String haystack, String[] needles) {
+        String lower = haystack.toLowerCase(Locale.ROOT);
+        for (String needle : needles) {
+            if (lower.contains(needle)) return true;
+        }
+        return false;
+    }
+}

--- a/openfilz-api/src/main/java/org/openfilz/dms/service/ai/AiFallbackChain.java
+++ b/openfilz-api/src/main/java/org/openfilz/dms/service/ai/AiFallbackChain.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Component;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
@@ -21,52 +22,70 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * The ordered list of chat models to try for one request, plus the per-model cooldown registry
- * that remembers which ones are currently out of quota.
+ * The ordered list of (model, API key) candidates to try for one request, plus the cooldown
+ * registry that remembers which combinations are currently out of quota.
  * <p>
- * Free provider tiers (Google's especially) hand out small per-minute and per-day allowances, so
- * a busy afternoon can exhaust the primary model. With
- * {@code openfilz.ai.fallback.enabled=true} the chat pipeline then walks
- * {@code openfilz.ai.fallback.chain} — {@code provider:model} entries, tried in order — instead of
- * failing the user's question.
+ * Free provider tiers meter requests <em>per key</em>, per model, per minute and per day, so a
+ * busy afternoon exhausts the primary model. With {@code openfilz.ai.fallback.enabled=true} the
+ * chat pipeline walks {@code openfilz.ai.fallback.chain} — {@code provider:model} entries, tried
+ * in order — and each provider may carry a pool of keys in
+ * {@code openfilz.ai.fallback.keys.<provider>} instead of the single {@code spring.ai.*.api-key}.
+ *
+ * <h2>How candidates are ordered</h2>
+ * A provider is exhausted completely — every chain model on every key — before the next provider
+ * is touched:
+ * <pre>
+ *   google:     m1/keyA   m2/keyA   m1/keyB   m2/keyB
+ *   anthropic:  c1/keyX   c1/keyY
+ * </pre>
+ * So the key rotates as soon as a provider has nothing left to offer on the current one, and a
+ * different provider is only reached once the previous one is spent outright. Chain order decides
+ * <em>provider</em> priority (by first appearance) and model priority within a provider; an
+ * interleaved chain such as {@code google:m1,anthropic:c1,google:m2} is therefore grouped as
+ * {@code google:m1,google:m2} then {@code anthropic:c1}, because key rotation is inherently a
+ * per-provider decision.
  * <p>
- * Two distinct mechanisms, and both matter:
+ * Which key is "current" is derived from the cooldown registry rather than held in a pointer: a
+ * provider's usable keys are those with at least one chain model still healthy. A key that went
+ * out of quota an hour ago simply drops out of the list, and rejoins it when the cooldown lapses.
+ *
+ * <h2>Two mechanisms, both needed</h2>
  * <ul>
- *   <li><b>Failover</b> — the request that hits the quota is retried on the next model, so the
+ *   <li><b>Failover</b> — the request that hit the quota is retried on the next candidate, so the
  *       user still gets an answer (see {@code AiChatServiceImpl}).</li>
- *   <li><b>Cooldown</b> — the model that failed is marked unavailable for a while, so the
- *       <em>following</em> requests skip straight to a model that works instead of each paying a
- *       failing round-trip first. This is what stops a spent daily quota from adding latency to
- *       every request for the rest of the day. Cooldowns expire on their own, so the primary
- *       model comes back into rotation without an operator touching anything.</li>
+ *   <li><b>Cooldown</b> — the failed (model, key) pair is benched, so the <em>following</em>
+ *       requests skip it instead of each paying a failing round-trip. Without it a spent daily
+ *       quota would add a failing call to every request for the rest of the day. Cooldowns expire
+ *       on their own, returning the pair to rotation with no operator action.</li>
  * </ul>
- * Cooldown state is per-instance and in-memory: it is a latency optimisation, not a correctness
- * mechanism, so a restart (or a second replica warming up its own view) simply costs one failed
- * call per model before it re-learns.
+ * Cooldown state is per-instance and in-memory: a latency optimisation, not a correctness
+ * mechanism, so a restart (or a second replica) costs one failed call per pair before it relearns.
  * <p>
- * Chain entries are limited to the API-key providers OpenFilz already builds programmatically
- * ({@code GOOGLE}, {@code ANTHROPIC}, {@code OPENAI}, {@code OPENAI_COMPATIBLE}) — the same
- * {@link UserChatClientResolver#buildChatModel} path BYOK uses. Ollama is deliberately absent:
- * it is the server default's own business, has no quota to exhaust, and its model is built by
- * Spring AI auto-configuration rather than by hand.
+ * Chain entries are limited to the API-key providers OpenFilz already builds programmatically —
+ * the same {@link UserChatClientResolver#buildChatModel} path BYOK uses. Ollama is deliberately
+ * absent: it is local, has no quota to exhaust, and its model comes from Spring AI
+ * auto-configuration rather than being built by hand.
  */
 @Slf4j
 @Component
 @Lazy
 public class AiFallbackChain {
 
+    /** One {@code provider:model} entry of the configured chain. */
+    private record ChainEntry(AiProvider provider, String model) {}
+
     private final AiProperties aiProperties;
     private final UserChatClientResolver resolver;
     private final Environment environment;
 
-    /** Model key -> instant the cooldown expires. Absent (or past) means the model is usable. */
+    /** {@code provider:keyRef:model} -> instant the cooldown expires. Absent or past means usable. */
     private final Map<String, Instant> cooldowns = new ConcurrentHashMap<>();
 
-    /** Built fallback models, cached because each one carries a pooled HTTP client. */
+    /** Built models, cached because each carries a pooled HTTP client. Keyed like the cooldowns. */
     private final Map<String, ResolvedChat> models = new ConcurrentHashMap<>();
 
-    /** Provider keys whose API key is missing, so we stop rebuilding (and re-logging) them. */
-    private final Set<String> unconfigured = ConcurrentHashMap.newKeySet();
+    /** {@code provider:keyRef} pairs whose client refused to build, so we stop retrying them. */
+    private final Set<String> unusable = ConcurrentHashMap.newKeySet();
 
     public AiFallbackChain(AiProperties aiProperties, UserChatClientResolver resolver, Environment environment) {
         this.aiProperties = aiProperties;
@@ -94,7 +113,7 @@ public class AiFallbackChain {
         List<ResolvedChat> out = new ArrayList<>();
         Set<String> seen = new LinkedHashSet<>();
 
-        String primaryKey = key(primary.provider(), primary.model());
+        String primaryKey = cooldownKey(primary.provider(), primary.keyRef(), primary.model());
         seen.add(primaryKey);
         if (isHealthy(primaryKey, now)) {
             out.add(primary);
@@ -102,12 +121,22 @@ public class AiFallbackChain {
             log.debug("[AI-FALLBACK] Skipping primary {} — cooling down until {}", primaryKey, cooldowns.get(primaryKey));
         }
 
-        for (String entry : aiProperties.getFallback().getChain()) {
-            ResolvedChat candidate = parseAndBuild(entry, seen, now);
-            if (candidate != null) {
-                out.add(candidate);
+        // Group the chain by provider, keeping each provider's first appearance as its priority
+        // and the chain order of its own models. Key rotation is a per-provider decision, so a
+        // provider has to be handled as a unit rather than entry by entry.
+        Map<AiProvider, List<String>> chainModels = modelsByProvider(parseChain());
+        Map<AiProvider, List<String>> usableKeys = usableKeysByProvider(chainModels, now);
+
+        chainModels.forEach((provider, providerModels) -> {
+            for (String apiKey : usableKeys.getOrDefault(provider, List.of())) {
+                for (String model : providerModels) {
+                    ResolvedChat candidate = candidate(provider, model, apiKey, seen, now);
+                    if (candidate != null) {
+                        out.add(candidate);
+                    }
+                }
             }
-        }
+        });
 
         if (out.isEmpty()) {
             log.warn("[AI-FALLBACK] Every candidate is cooling down — retrying the primary {} anyway", primaryKey);
@@ -116,45 +145,21 @@ public class AiFallbackChain {
         return out;
     }
 
-    /** Parse one {@code provider:model} chain entry into a usable candidate, or null to skip it. */
-    private ResolvedChat parseAndBuild(String entry, Set<String> seen, Instant now) {
-        if (entry == null || entry.isBlank()) return null;
+    /** Build (or reuse) the candidate for one model on one key, or null when it is unusable. */
+    private ResolvedChat candidate(AiProvider provider, String model, String apiKey, Set<String> seen, Instant now) {
+        String keyRef = AiKeyRef.of(apiKey);
+        String modelKey = cooldownKey(provider.name(), keyRef, model);
 
-        int separator = entry.indexOf(':');
-        if (separator <= 0 || separator == entry.length() - 1) {
-            log.warn("[AI-FALLBACK] Ignoring malformed chain entry '{}' — expected 'provider:model'", entry);
-            return null;
-        }
-        AiProvider provider = provider(entry.substring(0, separator).trim());
-        String model = entry.substring(separator + 1).trim();
-        if (provider == null) {
-            log.warn("[AI-FALLBACK] Ignoring chain entry '{}' — unknown provider (expected one of "
-                    + "google, anthropic, openai, openai-compatible)", entry);
-            return null;
-        }
-
-        String modelKey = key(provider.name(), model);
         if (!seen.add(modelKey)) return null;          // already the primary, or listed twice
-        if (!isHealthy(modelKey, now)) {
-            log.debug("[AI-FALLBACK] Skipping {} — cooling down until {}", modelKey, cooldowns.get(modelKey));
-            return null;
-        }
-        if (unconfigured.contains(provider.name())) return null;
+        if (!isHealthy(modelKey, now)) return null;    // benched (usableKeys only checked the provider)
+        if (unusable.contains(providerKey(provider, keyRef))) return null;
 
         ResolvedChat cached = models.get(modelKey);
         if (cached != null) return cached;
 
-        String apiKey = apiKey(provider);
-        if (apiKey == null) {
-            // Remembered, so a chain listing a provider the deployment has no key for costs one
-            // warning rather than one per request.
-            unconfigured.add(provider.name());
-            log.warn("[AI-FALLBACK] Chain entry '{}' is unusable — no API key configured for {}", entry, provider);
-            return null;
-        }
         try {
             ChatModel chatModel = resolver.buildChatModel(provider, apiKey, baseUrl(provider), model);
-            ResolvedChat built = new ResolvedChat(chatModel, provider.name(), model);
+            ResolvedChat built = new ResolvedChat(chatModel, provider.name(), model, keyRef);
             models.put(modelKey, built);
             log.info("[AI-FALLBACK] Prepared fallback model {}", modelKey);
             return built;
@@ -162,14 +167,71 @@ public class AiFallbackChain {
             // A provider client that refuses to build must not take the whole chat request down:
             // the remaining candidates are still worth trying.
             log.warn("[AI-FALLBACK] Could not build fallback model {} — skipping it: {}", modelKey, e.toString());
-            unconfigured.add(provider.name());
+            unusable.add(providerKey(provider, keyRef));
             return null;
         }
     }
 
+    /** Chain models grouped by provider, both kept in chain order (providers by first appearance). */
+    private Map<AiProvider, List<String>> modelsByProvider(List<ChainEntry> entries) {
+        Map<AiProvider, List<String>> grouped = new LinkedHashMap<>();
+        for (ChainEntry entry : entries) {
+            List<String> models = grouped.computeIfAbsent(entry.provider(), p -> new ArrayList<>());
+            if (!models.contains(entry.model())) {
+                models.add(entry.model());
+            }
+        }
+        return grouped;
+    }
+
     /**
-     * Record that a model just failed, so subsequent requests skip it until its cooldown expires.
-     * A retired model gets the longer cooldown — unlike a spent quota it will not come back.
+     * Per provider, the keys still worth trying: those with at least one chain model not benched.
+     * <p>
+     * Filtering here (rather than per model) is what makes key rotation provider-wide — a key
+     * disappears from the list only once the provider has nothing left to offer on it.
+     */
+    private Map<AiProvider, List<String>> usableKeysByProvider(Map<AiProvider, List<String>> chainModels, Instant now) {
+        Map<AiProvider, List<String>> usable = new LinkedHashMap<>();
+        chainModels.forEach((provider, providerModels) -> {
+            List<String> keys = new ArrayList<>();
+            for (String apiKey : keyPool(provider)) {
+                String keyRef = AiKeyRef.of(apiKey);
+                if (unusable.contains(providerKey(provider, keyRef))) continue;
+                boolean anyModelHealthy = providerModels.stream()
+                        .anyMatch(model -> isHealthy(cooldownKey(provider.name(), keyRef, model), now));
+                if (anyModelHealthy) {
+                    keys.add(apiKey);
+                } else {
+                    log.debug("[AI-FALLBACK] {} key {} is spent for every chain model — rotating past it",
+                            provider, keyRef);
+                }
+            }
+            usable.put(provider, keys);
+        });
+        return usable;
+    }
+
+    /**
+     * The keys to try for a provider: its configured pool, or the single server API key when no
+     * pool is set (so an existing single-key deployment keeps working untouched).
+     */
+    private List<String> keyPool(AiProvider provider) {
+        List<String> configured = aiProperties.getFallback().getKeys().get(provider);
+        List<String> pool = configured == null ? List.of() : configured.stream()
+                .filter(key -> key != null && !key.isBlank() && !"disabled".equalsIgnoreCase(key.trim()))
+                .map(String::trim)
+                .distinct()
+                .toList();
+        if (!pool.isEmpty()) return pool;
+
+        String single = serverApiKey(provider);
+        return single == null ? List.of() : List.of(single);
+    }
+
+    /**
+     * Record that a candidate just failed, so subsequent requests skip that (model, key) pair
+     * until its cooldown expires. A retired model gets the longer cooldown — unlike a spent quota
+     * it will not come back.
      */
     public void trip(ResolvedChat chat, Failure failure) {
         trip(chat, failure, Instant.now());
@@ -184,12 +246,12 @@ public class AiFallbackChain {
                 : config.getQuotaCooldown();
         if (cooldown == null || cooldown.isZero() || cooldown.isNegative()) return;
 
-        String modelKey = key(chat.provider(), chat.model());
+        String modelKey = cooldownKey(chat.provider(), chat.keyRef(), chat.model());
         cooldowns.put(modelKey, now.plus(cooldown));
         log.warn("[AI-FALLBACK] {} on {} — benching it for {}", failure, modelKey, cooldown);
     }
 
-    /** Whether this model may be tried right now. */
+    /** Whether this (provider, key, model) may be tried right now. */
     boolean isHealthy(String modelKey, Instant now) {
         Instant until = cooldowns.get(modelKey);
         if (until == null) return true;
@@ -198,13 +260,40 @@ public class AiFallbackChain {
         return true;
     }
 
+    /** Parse the configured chain, dropping (and reporting) entries we cannot act on. */
+    private List<ChainEntry> parseChain() {
+        List<ChainEntry> entries = new ArrayList<>();
+        for (String entry : aiProperties.getFallback().getChain()) {
+            if (entry == null || entry.isBlank()) continue;
+            int separator = entry.indexOf(':');
+            if (separator <= 0 || separator == entry.length() - 1) {
+                log.warn("[AI-FALLBACK] Ignoring malformed chain entry '{}' — expected 'provider:model'", entry);
+                continue;
+            }
+            AiProvider provider = provider(entry.substring(0, separator).trim());
+            if (provider == null) {
+                log.warn("[AI-FALLBACK] Ignoring chain entry '{}' — unknown provider (expected one of "
+                        + "google, anthropic, openai, openai-compatible)", entry);
+                continue;
+            }
+            entries.add(new ChainEntry(provider, entry.substring(separator + 1).trim()));
+        }
+        return entries;
+    }
+
     /**
      * Canonical cooldown key. Needed because the same model reaches us under two different
      * provider spellings: Spring AI's selector name for the server default ({@code google-genai})
      * and the {@link AiProvider} name for BYOK and chain entries ({@code GOOGLE}).
      */
-    static String key(String provider, String model) {
-        return canonicalProvider(provider) + ':' + (model == null ? "" : model.trim().toLowerCase(Locale.ROOT));
+    static String cooldownKey(String provider, String keyRef, String model) {
+        return canonicalProvider(provider)
+                + ':' + (keyRef == null || keyRef.isBlank() ? AiKeyRef.UNKNOWN : keyRef)
+                + ':' + (model == null ? "" : model.trim().toLowerCase(Locale.ROOT));
+    }
+
+    private static String providerKey(AiProvider provider, String keyRef) {
+        return canonicalProvider(provider.name()) + ':' + keyRef;
     }
 
     private static String canonicalProvider(String provider) {
@@ -232,11 +321,11 @@ public class AiFallbackChain {
     }
 
     /**
-     * The server-configured API key for a provider, or null when there is none.
+     * The single server-configured API key for a provider, or null when there is none.
      * {@code disabled} is the sentinel application.yml uses to keep provider auto-configuration
      * from failing at startup, so it counts as "not configured" here too.
      */
-    private String apiKey(AiProvider provider) {
+    private String serverApiKey(AiProvider provider) {
         String property = switch (provider) {
             case GOOGLE -> "spring.ai.google.genai.api-key";
             case ANTHROPIC -> "spring.ai.anthropic.api-key";

--- a/openfilz-api/src/main/java/org/openfilz/dms/service/ai/AiFallbackChain.java
+++ b/openfilz-api/src/main/java/org/openfilz/dms/service/ai/AiFallbackChain.java
@@ -1,0 +1,254 @@
+package org.openfilz.dms.service.ai;
+
+import lombok.extern.slf4j.Slf4j;
+import org.openfilz.dms.config.AiProperties;
+import org.openfilz.dms.enums.AiProvider;
+import org.openfilz.dms.service.ai.AiFailoverPolicy.Failure;
+import org.openfilz.dms.service.ai.UserChatClientResolver.ResolvedChat;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * The ordered list of chat models to try for one request, plus the per-model cooldown registry
+ * that remembers which ones are currently out of quota.
+ * <p>
+ * Free provider tiers (Google's especially) hand out small per-minute and per-day allowances, so
+ * a busy afternoon can exhaust the primary model. With
+ * {@code openfilz.ai.fallback.enabled=true} the chat pipeline then walks
+ * {@code openfilz.ai.fallback.chain} — {@code provider:model} entries, tried in order — instead of
+ * failing the user's question.
+ * <p>
+ * Two distinct mechanisms, and both matter:
+ * <ul>
+ *   <li><b>Failover</b> — the request that hits the quota is retried on the next model, so the
+ *       user still gets an answer (see {@code AiChatServiceImpl}).</li>
+ *   <li><b>Cooldown</b> — the model that failed is marked unavailable for a while, so the
+ *       <em>following</em> requests skip straight to a model that works instead of each paying a
+ *       failing round-trip first. This is what stops a spent daily quota from adding latency to
+ *       every request for the rest of the day. Cooldowns expire on their own, so the primary
+ *       model comes back into rotation without an operator touching anything.</li>
+ * </ul>
+ * Cooldown state is per-instance and in-memory: it is a latency optimisation, not a correctness
+ * mechanism, so a restart (or a second replica warming up its own view) simply costs one failed
+ * call per model before it re-learns.
+ * <p>
+ * Chain entries are limited to the API-key providers OpenFilz already builds programmatically
+ * ({@code GOOGLE}, {@code ANTHROPIC}, {@code OPENAI}, {@code OPENAI_COMPATIBLE}) — the same
+ * {@link UserChatClientResolver#buildChatModel} path BYOK uses. Ollama is deliberately absent:
+ * it is the server default's own business, has no quota to exhaust, and its model is built by
+ * Spring AI auto-configuration rather than by hand.
+ */
+@Slf4j
+@Component
+@Lazy
+public class AiFallbackChain {
+
+    private final AiProperties aiProperties;
+    private final UserChatClientResolver resolver;
+    private final Environment environment;
+
+    /** Model key -> instant the cooldown expires. Absent (or past) means the model is usable. */
+    private final Map<String, Instant> cooldowns = new ConcurrentHashMap<>();
+
+    /** Built fallback models, cached because each one carries a pooled HTTP client. */
+    private final Map<String, ResolvedChat> models = new ConcurrentHashMap<>();
+
+    /** Provider keys whose API key is missing, so we stop rebuilding (and re-logging) them. */
+    private final Set<String> unconfigured = ConcurrentHashMap.newKeySet();
+
+    public AiFallbackChain(AiProperties aiProperties, UserChatClientResolver resolver, Environment environment) {
+        this.aiProperties = aiProperties;
+        this.resolver = resolver;
+        this.environment = environment;
+    }
+
+    /**
+     * The models to try for this request, best first.
+     * <p>
+     * The user's own (or the server default) model leads unless it is cooling down, in which case
+     * the first healthy fallback takes its place. If every candidate is cooling down the primary
+     * is returned anyway: a real error from a real attempt beats refusing to try.
+     */
+    public List<ResolvedChat> candidates(ResolvedChat primary) {
+        AiProperties.Fallback config = aiProperties.getFallback();
+        if (!config.isEnabled() || config.getChain().isEmpty()) {
+            return List.of(primary);
+        }
+        return candidates(primary, Instant.now());
+    }
+
+    /** Package-private seam so tests can drive cooldown expiry without sleeping. */
+    List<ResolvedChat> candidates(ResolvedChat primary, Instant now) {
+        List<ResolvedChat> out = new ArrayList<>();
+        Set<String> seen = new LinkedHashSet<>();
+
+        String primaryKey = key(primary.provider(), primary.model());
+        seen.add(primaryKey);
+        if (isHealthy(primaryKey, now)) {
+            out.add(primary);
+        } else {
+            log.debug("[AI-FALLBACK] Skipping primary {} — cooling down until {}", primaryKey, cooldowns.get(primaryKey));
+        }
+
+        for (String entry : aiProperties.getFallback().getChain()) {
+            ResolvedChat candidate = parseAndBuild(entry, seen, now);
+            if (candidate != null) {
+                out.add(candidate);
+            }
+        }
+
+        if (out.isEmpty()) {
+            log.warn("[AI-FALLBACK] Every candidate is cooling down — retrying the primary {} anyway", primaryKey);
+            return List.of(primary);
+        }
+        return out;
+    }
+
+    /** Parse one {@code provider:model} chain entry into a usable candidate, or null to skip it. */
+    private ResolvedChat parseAndBuild(String entry, Set<String> seen, Instant now) {
+        if (entry == null || entry.isBlank()) return null;
+
+        int separator = entry.indexOf(':');
+        if (separator <= 0 || separator == entry.length() - 1) {
+            log.warn("[AI-FALLBACK] Ignoring malformed chain entry '{}' — expected 'provider:model'", entry);
+            return null;
+        }
+        AiProvider provider = provider(entry.substring(0, separator).trim());
+        String model = entry.substring(separator + 1).trim();
+        if (provider == null) {
+            log.warn("[AI-FALLBACK] Ignoring chain entry '{}' — unknown provider (expected one of "
+                    + "google, anthropic, openai, openai-compatible)", entry);
+            return null;
+        }
+
+        String modelKey = key(provider.name(), model);
+        if (!seen.add(modelKey)) return null;          // already the primary, or listed twice
+        if (!isHealthy(modelKey, now)) {
+            log.debug("[AI-FALLBACK] Skipping {} — cooling down until {}", modelKey, cooldowns.get(modelKey));
+            return null;
+        }
+        if (unconfigured.contains(provider.name())) return null;
+
+        ResolvedChat cached = models.get(modelKey);
+        if (cached != null) return cached;
+
+        String apiKey = apiKey(provider);
+        if (apiKey == null) {
+            // Remembered, so a chain listing a provider the deployment has no key for costs one
+            // warning rather than one per request.
+            unconfigured.add(provider.name());
+            log.warn("[AI-FALLBACK] Chain entry '{}' is unusable — no API key configured for {}", entry, provider);
+            return null;
+        }
+        try {
+            ChatModel chatModel = resolver.buildChatModel(provider, apiKey, baseUrl(provider), model);
+            ResolvedChat built = new ResolvedChat(chatModel, provider.name(), model);
+            models.put(modelKey, built);
+            log.info("[AI-FALLBACK] Prepared fallback model {}", modelKey);
+            return built;
+        } catch (Exception e) {
+            // A provider client that refuses to build must not take the whole chat request down:
+            // the remaining candidates are still worth trying.
+            log.warn("[AI-FALLBACK] Could not build fallback model {} — skipping it: {}", modelKey, e.toString());
+            unconfigured.add(provider.name());
+            return null;
+        }
+    }
+
+    /**
+     * Record that a model just failed, so subsequent requests skip it until its cooldown expires.
+     * A retired model gets the longer cooldown — unlike a spent quota it will not come back.
+     */
+    public void trip(ResolvedChat chat, Failure failure) {
+        trip(chat, failure, Instant.now());
+    }
+
+    /** Package-private seam so tests can drive cooldown expiry without sleeping. */
+    void trip(ResolvedChat chat, Failure failure, Instant now) {
+        if (!failure.shouldFailover()) return;
+        AiProperties.Fallback config = aiProperties.getFallback();
+        Duration cooldown = failure == Failure.MODEL_UNAVAILABLE
+                ? config.getUnavailableCooldown()
+                : config.getQuotaCooldown();
+        if (cooldown == null || cooldown.isZero() || cooldown.isNegative()) return;
+
+        String modelKey = key(chat.provider(), chat.model());
+        cooldowns.put(modelKey, now.plus(cooldown));
+        log.warn("[AI-FALLBACK] {} on {} — benching it for {}", failure, modelKey, cooldown);
+    }
+
+    /** Whether this model may be tried right now. */
+    boolean isHealthy(String modelKey, Instant now) {
+        Instant until = cooldowns.get(modelKey);
+        if (until == null) return true;
+        if (now.isBefore(until)) return false;
+        cooldowns.remove(modelKey, until);   // cooldown served — back into rotation
+        return true;
+    }
+
+    /**
+     * Canonical cooldown key. Needed because the same model reaches us under two different
+     * provider spellings: Spring AI's selector name for the server default ({@code google-genai})
+     * and the {@link AiProvider} name for BYOK and chain entries ({@code GOOGLE}).
+     */
+    static String key(String provider, String model) {
+        return canonicalProvider(provider) + ':' + (model == null ? "" : model.trim().toLowerCase(Locale.ROOT));
+    }
+
+    private static String canonicalProvider(String provider) {
+        if (provider == null) return "";
+        String normalised = provider.trim().toLowerCase(Locale.ROOT);
+        return switch (normalised) {
+            case "google-genai", "google", "gemini", "googlegenai" -> "google";
+            case "anthropic", "claude" -> "anthropic";
+            case "openai" -> "openai";
+            case "openai_compatible", "openai-compatible" -> "openai-compatible";
+            case "ollama" -> "ollama";
+            default -> normalised;
+        };
+    }
+
+    /** Map a chain entry's provider token onto the enum, or null when it names nothing we can build. */
+    private static AiProvider provider(String token) {
+        return switch (canonicalProvider(token)) {
+            case "google" -> AiProvider.GOOGLE;
+            case "anthropic" -> AiProvider.ANTHROPIC;
+            case "openai" -> AiProvider.OPENAI;
+            case "openai-compatible" -> AiProvider.OPENAI_COMPATIBLE;
+            default -> null;
+        };
+    }
+
+    /**
+     * The server-configured API key for a provider, or null when there is none.
+     * {@code disabled} is the sentinel application.yml uses to keep provider auto-configuration
+     * from failing at startup, so it counts as "not configured" here too.
+     */
+    private String apiKey(AiProvider provider) {
+        String property = switch (provider) {
+            case GOOGLE -> "spring.ai.google.genai.api-key";
+            case ANTHROPIC -> "spring.ai.anthropic.api-key";
+            case OPENAI, OPENAI_COMPATIBLE -> "spring.ai.openai.api-key";
+        };
+        String value = environment.getProperty(property);
+        return (value == null || value.isBlank() || "disabled".equalsIgnoreCase(value)) ? null : value;
+    }
+
+    private String baseUrl(AiProvider provider) {
+        return provider == AiProvider.OPENAI_COMPATIBLE
+                ? environment.getProperty("spring.ai.openai.base-url")
+                : null;
+    }
+}

--- a/openfilz-api/src/main/java/org/openfilz/dms/service/ai/AiKeyRef.java
+++ b/openfilz-api/src/main/java/org/openfilz/dms/service/ai/AiKeyRef.java
@@ -1,0 +1,45 @@
+package org.openfilz.dms.service.ai;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+/**
+ * Short, stable, non-reversible references to API keys.
+ * <p>
+ * Quota is charged per key, so the failover machinery has to tell one key of a provider from
+ * another: which key a model was benched under, which key a cached client belongs to, which key
+ * a log line is about. Doing that with the key itself would put live credentials into cooldown
+ * maps, cache keys and log output, so everything downstream of {@link #of} handles this
+ * fingerprint instead — enough to distinguish keys, useless to anyone who reads a log.
+ */
+public final class AiKeyRef {
+
+    private AiKeyRef() {
+    }
+
+    /** Used when a model's key is not known to us — a BYOK client built elsewhere, say. */
+    public static final String UNKNOWN = "unknown";
+
+    /** Bytes of SHA-256 kept: 4 bytes (8 hex chars) is far more than enough to separate a handful of keys. */
+    private static final int FINGERPRINT_BYTES = 4;
+
+    /**
+     * A short fingerprint of an API key, safe to log and to use as a map key.
+     * Blank or null input yields {@link #UNKNOWN} rather than a fingerprint of the empty string,
+     * so "no key" never collides with a real one.
+     */
+    public static String of(String apiKey) {
+        if (apiKey == null || apiKey.isBlank()) return UNKNOWN;
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256").digest(apiKey.getBytes(StandardCharsets.UTF_8));
+            byte[] truncated = new byte[FINGERPRINT_BYTES];
+            System.arraycopy(digest, 0, truncated, 0, FINGERPRINT_BYTES);
+            return HexFormat.of().formatHex(truncated);
+        } catch (NoSuchAlgorithmException e) {
+            // SHA-256 is mandated by the JLS on every conforming JRE; unreachable in practice.
+            throw new IllegalStateException("SHA-256 is unavailable", e);
+        }
+    }
+}

--- a/openfilz-api/src/main/java/org/openfilz/dms/service/ai/DocumentAiTools.java
+++ b/openfilz-api/src/main/java/org/openfilz/dms/service/ai/DocumentAiTools.java
@@ -1,5 +1,6 @@
 package org.openfilz.dms.service.ai;
 
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.openfilz.dms.dto.request.*;
@@ -53,7 +54,14 @@ public class DocumentAiTools {
     private final DocumentRepository documentRepository;
     private final StorageService storageService;
     private final AiDocumentQueryService queryService;
-    private final ChatModel chatModel;
+    /**
+     * Model backing the vision tool ({@code describeImage}). Not final: when a chat request fails
+     * over to another model (see {@code AiFallbackChain}), {@link #rebindChatModel} repoints the
+     * vision tool at the model that actually answered, so a benched model is not still called
+     * from inside a tool. {@code @NonNull} keeps it in Lombok's generated constructor.
+     */
+    @NonNull
+    private ChatModel chatModel;
     private final AiAccessPolicy accessPolicy;
 
     /**
@@ -165,6 +173,17 @@ public class DocumentAiTools {
             log.warn("Invalid UUID '{}', treating as null", value);
             return null;
         }
+    }
+
+    /**
+     * Repoint the vision tool at another model after a chat failover.
+     * <p>
+     * Safe to mutate: instances are created per request by {@code DocumentAiToolsFactory}, and
+     * failover happens between streaming attempts on that single request — never concurrently
+     * with a tool call.
+     */
+    public void rebindChatModel(ChatModel chatModel) {
+        this.chatModel = chatModel;
     }
 
     /** Clear the registry before each new user message. */

--- a/openfilz-api/src/main/java/org/openfilz/dms/service/ai/UserChatClientResolver.java
+++ b/openfilz-api/src/main/java/org/openfilz/dms/service/ai/UserChatClientResolver.java
@@ -48,8 +48,21 @@ import java.util.List;
 @Lazy
 public class UserChatClientResolver {
 
-    /** A resolved chat model with display metadata for the frontend badge. */
-    public record ResolvedChat(ChatModel chatModel, String provider, String model) {}
+    /**
+     * A resolved chat model with display metadata for the frontend badge, plus a fingerprint of
+     * the API key behind it.
+     * <p>
+     * The fingerprint (never the key) lets {@link AiFallbackChain} bench a model <em>per key</em>:
+     * quota is charged per key, so "gemini-3.6-flash is out of quota" is only ever true of one
+     * key at a time, and two BYOK users on the same provider and model must not share a cooldown.
+     */
+    public record ResolvedChat(ChatModel chatModel, String provider, String model, String keyRef) {
+
+        /** For callers with no key to declare; the model is then benched under its own bucket. */
+        public ResolvedChat(ChatModel chatModel, String provider, String model) {
+            this(chatModel, provider, model, AiKeyRef.UNKNOWN);
+        }
+    }
 
     private record CachedModel(String configHash, ResolvedChat resolved) {}
 
@@ -117,7 +130,7 @@ public class UserChatClientResolver {
         AiProvider provider = AiProvider.valueOf(settings.getProvider());
         String apiKey = cipher.decrypt(settings.getApiKeyEncrypted());
         ChatModel model = buildChatModel(provider, apiKey, settings.getBaseUrl(), settings.getModel());
-        ResolvedChat resolved = new ResolvedChat(model, provider.name(), settings.getModel());
+        ResolvedChat resolved = new ResolvedChat(model, provider.name(), settings.getModel(), AiKeyRef.of(apiKey));
         cache.put(userEmail, new CachedModel(hash, resolved));
         log.debug("[AI] Built {} chat model ({}) for user {}", provider, settings.getModel(), userEmail);
         return resolved;
@@ -173,7 +186,26 @@ public class UserChatClientResolver {
 
     private ResolvedChat defaultChat() {
         String provider = environment.getProperty("spring.ai.model.chat", "none");
-        return new ResolvedChat(defaultChatModel, provider, defaultModelFor(provider));
+        return new ResolvedChat(defaultChatModel, provider, defaultModelFor(provider), defaultKeyRefFor(provider));
+    }
+
+    /**
+     * Fingerprint of the key the active provider's auto-configuration is using, so the server
+     * default and a fallback-chain entry naming the same provider+model+key are recognised as the
+     * same candidate instead of both being tried.
+     */
+    private String defaultKeyRefFor(String provider) {
+        String property = switch (provider) {
+            case "anthropic" -> "spring.ai.anthropic.api-key";
+            case "google-genai" -> "spring.ai.google.genai.api-key";
+            case "openai" -> "spring.ai.openai.api-key";
+            default -> null;   // ollama needs no key
+        };
+        if (property == null) return AiKeyRef.UNKNOWN;
+        String key = environment.getProperty(property);
+        // 'disabled' is the application.yml sentinel that keeps auto-configuration from failing.
+        return (key == null || key.isBlank() || "disabled".equalsIgnoreCase(key))
+                ? AiKeyRef.UNKNOWN : AiKeyRef.of(key);
     }
 
     /** Display model for the server default, resolved from the active provider's config. */

--- a/openfilz-api/src/main/java/org/openfilz/dms/service/impl/AiChatServiceImpl.java
+++ b/openfilz-api/src/main/java/org/openfilz/dms/service/impl/AiChatServiceImpl.java
@@ -11,10 +11,13 @@ import org.openfilz.dms.repository.AiChatConversationRepository;
 import org.openfilz.dms.repository.AiChatMessageRepository;
 import org.openfilz.dms.service.AiChatService;
 import org.openfilz.dms.service.ai.AiAccessPolicy;
+import org.openfilz.dms.service.ai.AiFailoverPolicy;
+import org.openfilz.dms.service.ai.AiFallbackChain;
 import org.openfilz.dms.service.ai.ChatClientAssembler;
 import org.openfilz.dms.service.ai.DocumentAiTools;
 import org.openfilz.dms.service.ai.DocumentAiToolsFactory;
 import org.openfilz.dms.service.ai.UserChatClientResolver;
+import org.openfilz.dms.service.ai.UserChatClientResolver.ResolvedChat;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
@@ -56,6 +59,7 @@ import java.util.UUID;
 public class AiChatServiceImpl implements AiChatService {
 
     private final UserChatClientResolver chatResolver;
+    private final AiFallbackChain fallbackChain;
     private final ChatClientAssembler assembler;
     private final DocumentAiToolsFactory toolsFactory;
     private final VectorStore vectorStore;
@@ -89,10 +93,14 @@ public class AiChatServiceImpl implements AiChatService {
             // 2. Resolve the user's chat model (server default or BYOK) and build the
             //    per-request tool instance + client on top of it.
             return chatResolver.resolve(userEmail).flatMapMany(resolved -> {
-                DocumentAiTools tools = toolsFactory.create(resolved.chatModel(), userEmail, authentication);
-                ChatClient chatClient = assembler.assemble(resolved.chatModel(), tools);
+                // Models to try, best first: the user's own (or the server default) unless it is
+                // cooling down after a quota failure, then the configured fallbacks.
+                List<ResolvedChat> candidates = fallbackChain.candidates(resolved);
+                ResolvedChat first = candidates.getFirst();
+                DocumentAiTools tools = toolsFactory.create(first.chatModel(), userEmail, authentication);
                 Set<String> ragDocumentNames = new HashSet<>();
-                log.debug("[AI] Chat model: {} ({})", resolved.provider(), resolved.model());
+                log.debug("[AI] Chat model: {} ({}){}", first.provider(), first.model(),
+                        candidates.size() > 1 ? " (+" + (candidates.size() - 1) + " fallback)" : "");
 
                 // 3. Save user message
                 Mono<Void> saveUserMsg = saveMessage(conversationId, "USER", request.getMessage())
@@ -123,17 +131,7 @@ public class AiChatServiceImpl implements AiChatService {
                             StringBuilder fullResponse = new StringBuilder();
 
                             log.debug("[AI] Sending prompt to LLM (streaming)...");
-                            return chatClient.prompt()
-                                    .messages(history)
-                                    .user(augmentedMessage)
-                                    .stream()
-                                    .content()
-                                    .doOnNext(chunk -> {
-                                        fullResponse.append(chunk);
-                                        if (fullResponse.length() == chunk.length()) {
-                                            log.debug("[AI] LLM started streaming response");
-                                        }
-                                    })
+                            return streamWithFailover(candidates, 0, tools, history, augmentedMessage, fullResponse)
                                     .doOnComplete(() -> log.debug("[AI] LLM streaming complete, raw response: {} chars", fullResponse.length()))
                                     .then(Mono.defer(() -> {
                                         // Post-process: enrich response with document links
@@ -180,6 +178,67 @@ public class AiChatServiceImpl implements AiChatService {
                         });
             });
         });
+    }
+
+    /**
+     * Stream the answer from {@code candidates[index]}, falling over to the next candidate when
+     * the model refuses for a reason another model could survive (quota exhausted, model retired,
+     * provider down — see {@link AiFailoverPolicy}).
+     * <p>
+     * Two conditions must hold before a retry, and both are about not showing the user something
+     * wrong:
+     * <ul>
+     *   <li><b>Nothing streamed yet.</b> Once tokens have reached the client, restarting on another
+     *       model would splice two different answers together, so a mid-stream failure propagates.</li>
+     *   <li><b>No tool has mutated anything.</b> Read-only tools are safe to repeat, but a retry
+     *       after a move/rename/delete would run it twice. {@code modifiedFolders} is empty exactly
+     *       when no mutating tool has fired this turn.</li>
+     * </ul>
+     * The failed model is benched in {@link AiFallbackChain} on the way out, so the requests that
+     * follow skip it instead of each paying the same failing call.
+     */
+    private Flux<String> streamWithFailover(List<ResolvedChat> candidates, int index, DocumentAiTools tools,
+                                            List<Message> history, String augmentedMessage, StringBuilder fullResponse) {
+        ResolvedChat candidate = candidates.get(index);
+        tools.rebindChatModel(candidate.chatModel());
+        ChatClient chatClient = assembler.assemble(candidate.chatModel(), tools);
+
+        return chatClient.prompt()
+                .messages(history)
+                .user(augmentedMessage)
+                .stream()
+                .content()
+                .doOnNext(chunk -> {
+                    fullResponse.append(chunk);
+                    if (fullResponse.length() == chunk.length()) {
+                        log.debug("[AI] LLM started streaming response");
+                    }
+                })
+                .onErrorResume(error -> {
+                    AiFailoverPolicy.Failure failure = AiFailoverPolicy.classify(error);
+                    fallbackChain.trip(candidate, failure);
+
+                    boolean hasNextCandidate = index + 1 < candidates.size();
+                    boolean nothingStreamed = fullResponse.isEmpty();
+                    boolean nothingMutated = tools.getModifiedFolders().isEmpty();
+
+                    if (!failure.shouldFailover() || !hasNextCandidate || !nothingStreamed || !nothingMutated) {
+                        if (failure.shouldFailover() && !hasNextCandidate) {
+                            log.error("[AI] {} on {} ({}) and no fallback model left",
+                                    failure, candidate.provider(), candidate.model());
+                        } else if (failure.shouldFailover()) {
+                            log.error("[AI] {} on {} ({}) but cannot retry safely (streamed={}, mutated={})",
+                                    failure, candidate.provider(), candidate.model(),
+                                    !nothingStreamed, !nothingMutated);
+                        }
+                        return Flux.error(error);
+                    }
+
+                    ResolvedChat next = candidates.get(index + 1);
+                    log.warn("[AI] {} on {} ({}) — falling back to {} ({})", failure,
+                            candidate.provider(), candidate.model(), next.provider(), next.model());
+                    return streamWithFailover(candidates, index + 1, tools, history, augmentedMessage, fullResponse);
+                });
     }
 
     @Override

--- a/openfilz-api/src/main/resources/application.yml
+++ b/openfilz-api/src/main/resources/application.yml
@@ -136,6 +136,16 @@ openfilz:
     fallback:
       enabled: ${AI_FALLBACK_ENABLED:false}
       chain: ${AI_FALLBACK_CHAIN:}
+      # Extra API keys per provider, comma-separated and tried in order. Quota is charged per
+      # KEY, so once every chain model of a provider is spent on the key in use, the next key of
+      # that provider takes over and those models are available again. A provider left empty here
+      # keeps using its single spring.ai.*.api-key.
+      #   AI_FALLBACK_KEYS_GOOGLE=AIza-first,AIza-second
+      keys:
+        google: ${AI_FALLBACK_KEYS_GOOGLE:}
+        anthropic: ${AI_FALLBACK_KEYS_ANTHROPIC:}
+        openai: ${AI_FALLBACK_KEYS_OPENAI:}
+        openai-compatible: ${AI_FALLBACK_KEYS_OPENAI_COMPATIBLE:}
       quota-cooldown: ${AI_FALLBACK_QUOTA_COOLDOWN:5m}
       unavailable-cooldown: ${AI_FALLBACK_UNAVAILABLE_COOLDOWN:6h}
     # BYOK: users may override the chat LLM with their own provider + API key (personal settings).

--- a/openfilz-api/src/main/resources/application.yml
+++ b/openfilz-api/src/main/resources/application.yml
@@ -127,6 +127,17 @@ openfilz:
     google:
       chat:
         enabled: ${GOOGLE_CHAT_ENABLED:false}     # chat only — embeddings stay on Ollama/OpenAI (768-dim pgvector)
+    # Automatic failover when the active chat model refuses to answer — an exhausted free-tier
+    # quota, a retired model, or a provider that is down. The request is retried on the next
+    # model in the chain, and the failed one is benched for a cooldown so later requests skip it
+    # instead of each paying the same failing call. Credential failures never fail over.
+    # Chain entries are 'provider:model', tried in order; each provider needs its API key set.
+    #   AI_FALLBACK_CHAIN=google:gemini-3.6-flash,anthropic:claude-haiku-4-5,openai:gpt-4o-mini
+    fallback:
+      enabled: ${AI_FALLBACK_ENABLED:false}
+      chain: ${AI_FALLBACK_CHAIN:}
+      quota-cooldown: ${AI_FALLBACK_QUOTA_COOLDOWN:5m}
+      unavailable-cooldown: ${AI_FALLBACK_UNAVAILABLE_COOLDOWN:6h}
     # BYOK: users may override the chat LLM with their own provider + API key (personal settings).
     # Requires an encryption key for the stored API keys: openssl rand -base64 32
     user-settings:
@@ -293,7 +304,7 @@ spring.ai.anthropic:
 spring.ai.google.genai:
   api-key: ${GOOGLE_API_KEY:disabled}
   chat:
-    model: ${GOOGLE_CHAT_MODEL:gemini-2.5-flash}
+    model: ${GOOGLE_CHAT_MODEL:gemini-3.6-flash}
 
 # PgVector Store (auto-configured when spring-ai-starter-vector-store-pgvector is on classpath)
 spring.ai.vectorstore.pgvector:

--- a/openfilz-api/src/test/java/org/openfilz/dms/service/ai/AiFailoverPolicyTest.java
+++ b/openfilz-api/src/test/java/org/openfilz/dms/service/ai/AiFailoverPolicyTest.java
@@ -1,0 +1,151 @@
+package org.openfilz.dms.service.ai;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.openfilz.dms.service.ai.AiFailoverPolicy.Failure;
+
+import java.net.ConnectException;
+import java.net.UnknownHostException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Failure classification is the load-bearing half of chat-model failover: misread a broken API
+ * key as an exhausted quota and OpenFilz silently answers from the wrong model instead of telling
+ * the operator their key is wrong.
+ * <p>
+ * The provider SDK exceptions are not on the test classpath as constructible fixtures, and their
+ * real shape is what matters, so each case reproduces the message text and wrapping that the
+ * provider actually produces — most importantly the verbatim Google GenAI 404 that took a
+ * production deployment down when {@code gemini-2.5-flash} was retired.
+ */
+class AiFailoverPolicyTest {
+
+    /** Stand-in for {@code com.google.genai.errors.ClientException} (message shape is what we match on). */
+    private static class ClientException extends RuntimeException {
+        ClientException(String message) { super(message); }
+    }
+
+    /** Stand-in for the Anthropic/OpenAI SDKs' typed rate-limit exception (matched on type name). */
+    private static class RateLimitException extends RuntimeException {
+        RateLimitException(String message) { super(message); }
+    }
+
+    private static class AuthenticationException extends RuntimeException {
+        AuthenticationException(String message) { super(message); }
+    }
+
+    /** Spring AI wraps every provider failure in this generic runtime exception. */
+    private static RuntimeException springAiWrapped(Throwable cause) {
+        return new RuntimeException("Failed to generate content", cause);
+    }
+
+    @Test
+    @DisplayName("the retired-model 404 that broke production is a failover, not a hard error")
+    void classifiesRetiredGoogleModel() {
+        RuntimeException error = springAiWrapped(new ClientException(
+                "404 . This model models/gemini-2.5-flash is no longer available to new users. "
+                        + "Please update your code to use models/gemini-3.6-flash for the latest features and improvements."));
+
+        assertThat(AiFailoverPolicy.classify(error)).isEqualTo(Failure.MODEL_UNAVAILABLE);
+        assertThat(AiFailoverPolicy.classify(error).shouldFailover()).isTrue();
+    }
+
+    @Test
+    @DisplayName("exhausted quota is detected from status, wording and typed exceptions alike")
+    void classifiesQuotaExhaustion() {
+        assertThat(AiFailoverPolicy.classify(springAiWrapped(new ClientException(
+                "429 . RESOURCE_EXHAUSTED. You exceeded your current quota, please check your plan and billing details."))))
+                .isEqualTo(Failure.QUOTA_EXHAUSTED);
+
+        assertThat(AiFailoverPolicy.classify(new ClientException(
+                "429 . Quota exceeded for quota metric 'Generate Content API requests per day'")))
+                .isEqualTo(Failure.QUOTA_EXHAUSTED);
+
+        assertThat(AiFailoverPolicy.classify(springAiWrapped(new RateLimitException("rate limited"))))
+                .isEqualTo(Failure.QUOTA_EXHAUSTED);
+
+        assertThat(AiFailoverPolicy.classify(new RuntimeException("status code: 429, insufficient_quota")))
+                .isEqualTo(Failure.QUOTA_EXHAUSTED);
+    }
+
+    @Test
+    @DisplayName("some providers report a spent quota as 403 — the wording decides")
+    void classifiesQuotaReportedAsForbidden() {
+        assertThat(AiFailoverPolicy.classify(new ClientException("403 . Quota exceeded for this project")))
+                .isEqualTo(Failure.QUOTA_EXHAUSTED);
+        assertThat(AiFailoverPolicy.classify(new ClientException("403 . PERMISSION_DENIED: caller lacks permission")))
+                .isEqualTo(Failure.NOT_FAILOVER);
+    }
+
+    @Test
+    @DisplayName("provider outages and unreachable hosts are worth another model")
+    void classifiesTransientProviderFailures() {
+        assertThat(AiFailoverPolicy.classify(new ClientException("503 . The model is overloaded. Please try again later.")))
+                .isEqualTo(Failure.PROVIDER_OVERLOADED);
+        assertThat(AiFailoverPolicy.classify(new ClientException("500 . Internal error encountered.")))
+                .isEqualTo(Failure.PROVIDER_OVERLOADED);
+        // A local Ollama that is not running: exactly the "ollama: Temporary failure in name
+        // resolution" seen when the container is missing from the deployment.
+        assertThat(AiFailoverPolicy.classify(springAiWrapped(
+                new UnknownHostException("ollama: Temporary failure in name resolution"))))
+                .isEqualTo(Failure.PROVIDER_OVERLOADED);
+        assertThat(AiFailoverPolicy.classify(springAiWrapped(new ConnectException("Connection refused"))))
+                .isEqualTo(Failure.PROVIDER_OVERLOADED);
+    }
+
+    @Test
+    @DisplayName("credential and request errors never fail over — masking them hides the real fix")
+    void refusesToMaskConfigurationErrors() {
+        assertThat(AiFailoverPolicy.classify(new ClientException("401 . API key not valid. Please pass a valid API key.")))
+                .isEqualTo(Failure.NOT_FAILOVER);
+        assertThat(AiFailoverPolicy.classify(springAiWrapped(new AuthenticationException("invalid x-api-key"))))
+                .isEqualTo(Failure.NOT_FAILOVER);
+        assertThat(AiFailoverPolicy.classify(new ClientException("400 . Invalid JSON payload received.")))
+                .isEqualTo(Failure.NOT_FAILOVER);
+        assertThat(AiFailoverPolicy.classify(new NullPointerException("boom")))
+                .isEqualTo(Failure.NOT_FAILOVER);
+        assertThat(AiFailoverPolicy.classify(new RuntimeException()))
+                .isEqualTo(Failure.NOT_FAILOVER);
+        assertThat(Failure.NOT_FAILOVER.shouldFailover()).isFalse();
+    }
+
+    @Test
+    @DisplayName("digits inside model names are not mistaken for HTTP statuses")
+    void doesNotInventStatusCodes() {
+        assertThat(AiFailoverPolicy.classify(new ClientException(
+                "model gpt-4.1-mini-2025-04-14 produced an unexpected response shape")))
+                .isEqualTo(Failure.NOT_FAILOVER);
+        assertThat(AiFailoverPolicy.classify(new ClientException(
+                "claude-sonnet-4-5-20250929 returned an unparseable chunk")))
+                .isEqualTo(Failure.NOT_FAILOVER);
+    }
+
+    @Test
+    @DisplayName("the real signal is found however deeply Spring AI wraps it")
+    void walksTheCauseChain() {
+        Throwable deep = new ClientException("429 . quota");
+        for (int i = 0; i < 6; i++) {
+            deep = new RuntimeException("wrapper " + i, deep);
+        }
+        assertThat(AiFailoverPolicy.classify(deep)).isEqualTo(Failure.QUOTA_EXHAUSTED);
+    }
+
+    @Test
+    @DisplayName("a cyclic or absurdly deep cause chain terminates instead of hanging")
+    void survivesPathologicalCauseChains() {
+        // Throwable.initCause(this) is rejected by the JDK, so a genuine cycle can only arrive
+        // from a type that overrides getCause().
+        RuntimeException cyclic = new RuntimeException("cycle") {
+            @Override
+            public synchronized Throwable getCause() { return this; }
+        };
+        assertThat(AiFailoverPolicy.classify(cyclic)).isEqualTo(Failure.NOT_FAILOVER);
+
+        Throwable tooDeep = new ClientException("429 . quota");
+        for (int i = 0; i < 40; i++) {
+            tooDeep = new RuntimeException("w" + i, tooDeep);
+        }
+        assertThat(AiFailoverPolicy.classify(tooDeep)).isEqualTo(Failure.NOT_FAILOVER);
+    }
+}

--- a/openfilz-api/src/test/java/org/openfilz/dms/service/ai/AiFallbackChainTest.java
+++ b/openfilz-api/src/test/java/org/openfilz/dms/service/ai/AiFallbackChainTest.java
@@ -1,0 +1,172 @@
+package org.openfilz.dms.service.ai;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.openfilz.dms.config.AiProperties;
+import org.openfilz.dms.service.ai.AiFailoverPolicy.Failure;
+import org.openfilz.dms.service.ai.UserChatClientResolver.ResolvedChat;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.mock.env.MockEnvironment;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Candidate ordering and cooldown behaviour of the chat-model fallback chain.
+ * <p>
+ * Time is injected rather than slept on: every assertion about a cooldown expiring runs instantly.
+ */
+class AiFallbackChainTest {
+
+    private static final Instant T0 = Instant.parse("2026-08-22T00:00:00Z");
+
+    private AiProperties properties;
+    private MockEnvironment environment;
+    private UserChatClientResolver resolver;
+    private AiFallbackChain chain;
+
+    /** The server default the deployment starts from: Google, as in the reported deployment. */
+    private ResolvedChat primary;
+
+    @BeforeEach
+    void setUp() {
+        properties = new AiProperties();
+        properties.getFallback().setEnabled(true);
+        properties.getFallback().setChain(List.of("google:gemini-3.6-flash", "anthropic:claude-haiku-4-5"));
+
+        environment = new MockEnvironment();
+        environment.setProperty("spring.ai.google.genai.api-key", "google-key");
+        environment.setProperty("spring.ai.anthropic.api-key", "anthropic-key");
+
+        resolver = mock(UserChatClientResolver.class);
+        when(resolver.buildChatModel(any(), anyString(), any(), anyString()))
+                .thenAnswer(invocation -> mock(ChatModel.class));
+
+        chain = new AiFallbackChain(properties, resolver, environment);
+
+        // Note the provider spelling: the server default arrives as Spring AI's selector name
+        // ("google-genai"), while chain entries use the AiProvider name ("GOOGLE").
+        primary = new ResolvedChat(mock(ChatModel.class), "google-genai", "gemini-2.5-flash");
+    }
+
+    @Test
+    @DisplayName("failover off leaves the primary as the only candidate")
+    void disabledByDefault() {
+        properties.getFallback().setEnabled(false);
+        assertThat(chain.candidates(primary)).containsExactly(primary);
+    }
+
+    @Test
+    @DisplayName("healthy primary leads, fallbacks follow in configured order")
+    void ordersCandidates() {
+        List<ResolvedChat> candidates = chain.candidates(primary, T0);
+
+        assertThat(candidates).hasSize(3);
+        assertThat(candidates.getFirst()).isSameAs(primary);
+        assertThat(candidates.get(1).model()).isEqualTo("gemini-3.6-flash");
+        assertThat(candidates.get(2).model()).isEqualTo("claude-haiku-4-5");
+    }
+
+    @Test
+    @DisplayName("a benched model is skipped, so later requests stop paying for its failure")
+    void skipsCoolingDownPrimary() {
+        chain.trip(primary, Failure.QUOTA_EXHAUSTED, T0);
+
+        List<ResolvedChat> candidates = chain.candidates(primary, T0.plusSeconds(60));
+
+        assertThat(candidates).doesNotContain(primary);
+        assertThat(candidates.getFirst().model()).isEqualTo("gemini-3.6-flash");
+    }
+
+    @Test
+    @DisplayName("a quota cooldown expires on its own and the model returns to rotation")
+    void quotaCooldownExpires() {
+        properties.getFallback().setQuotaCooldown(Duration.ofMinutes(5));
+        chain.trip(primary, Failure.QUOTA_EXHAUSTED, T0);
+
+        assertThat(chain.candidates(primary, T0.plusSeconds(299))).doesNotContain(primary);
+        assertThat(chain.candidates(primary, T0.plusSeconds(301)).getFirst()).isSameAs(primary);
+    }
+
+    @Test
+    @DisplayName("a retired model is benched far longer than a spent quota")
+    void retiredModelGetsTheLongCooldown() {
+        properties.getFallback().setQuotaCooldown(Duration.ofMinutes(5));
+        properties.getFallback().setUnavailableCooldown(Duration.ofHours(6));
+
+        chain.trip(primary, Failure.MODEL_UNAVAILABLE, T0);
+
+        // Well past the quota cooldown, still benched — a 404 model is not coming back by itself.
+        assertThat(chain.candidates(primary, T0.plusSeconds(3600))).doesNotContain(primary);
+        assertThat(chain.candidates(primary, T0.plus(Duration.ofHours(7))).getFirst()).isSameAs(primary);
+    }
+
+    @Test
+    @DisplayName("a credential failure never benches a model")
+    void doesNotBenchOnAuthFailure() {
+        chain.trip(primary, Failure.NOT_FAILOVER, T0);
+        assertThat(chain.candidates(primary, T0).getFirst()).isSameAs(primary);
+    }
+
+    @Test
+    @DisplayName("the primary is retried rather than refused when everything is cooling down")
+    void fallsBackToPrimaryWhenAllBenched() {
+        properties.getFallback().setChain(List.of("google:gemini-3.6-flash"));
+        List<ResolvedChat> candidates = chain.candidates(primary, T0);
+        chain.trip(primary, Failure.QUOTA_EXHAUSTED, T0);
+        chain.trip(candidates.get(1), Failure.QUOTA_EXHAUSTED, T0);
+
+        assertThat(chain.candidates(primary, T0.plusSeconds(60))).containsExactly(primary);
+    }
+
+    @Test
+    @DisplayName("chain entries needing an unconfigured API key are skipped, not fatal")
+    void skipsProvidersWithoutApiKey() {
+        environment.setProperty("spring.ai.openai.api-key", "disabled");  // the application.yml sentinel
+        properties.getFallback().setChain(List.of("openai:gpt-4o-mini", "anthropic:claude-haiku-4-5"));
+
+        List<ResolvedChat> candidates = chain.candidates(primary, T0);
+
+        assertThat(candidates).hasSize(2);
+        assertThat(candidates.get(1).model()).isEqualTo("claude-haiku-4-5");
+    }
+
+    @Test
+    @DisplayName("malformed and unknown chain entries are ignored without breaking the chain")
+    void ignoresMalformedEntries() {
+        properties.getFallback().setChain(List.of("", "no-separator", "mystery:model", "anthropic:claude-haiku-4-5"));
+
+        List<ResolvedChat> candidates = chain.candidates(primary, T0);
+
+        assertThat(candidates).hasSize(2);
+        assertThat(candidates.get(1).model()).isEqualTo("claude-haiku-4-5");
+    }
+
+    @Test
+    @DisplayName("the primary is not offered twice when the chain also lists it")
+    void deduplicatesPrimary() {
+        // Same model as the primary, spelled with the AiProvider name instead of the selector name.
+        properties.getFallback().setChain(List.of("google:gemini-2.5-flash", "anthropic:claude-haiku-4-5"));
+
+        List<ResolvedChat> candidates = chain.candidates(primary, T0);
+
+        assertThat(candidates).hasSize(2);
+        assertThat(candidates.getFirst()).isSameAs(primary);
+        assertThat(candidates.get(1).model()).isEqualTo("claude-haiku-4-5");
+    }
+
+    @Test
+    @DisplayName("provider spelling differences resolve to the same cooldown entry")
+    void normalisesProviderSpelling() {
+        assertThat(AiFallbackChain.key("google-genai", "gemini-3.6-flash"))
+                .isEqualTo(AiFallbackChain.key("GOOGLE", "Gemini-3.6-Flash"));
+    }
+}

--- a/openfilz-api/src/test/java/org/openfilz/dms/service/ai/AiFallbackChainTest.java
+++ b/openfilz-api/src/test/java/org/openfilz/dms/service/ai/AiFallbackChainTest.java
@@ -2,8 +2,10 @@ package org.openfilz.dms.service.ai;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openfilz.dms.config.AiProperties;
+import org.openfilz.dms.enums.AiProvider;
 import org.openfilz.dms.service.ai.AiFailoverPolicy.Failure;
 import org.openfilz.dms.service.ai.UserChatClientResolver.ResolvedChat;
 import org.springframework.ai.chat.model.ChatModel;
@@ -11,162 +13,501 @@ import org.springframework.mock.env.MockEnvironment;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * Candidate ordering and cooldown behaviour of the chat-model fallback chain.
+ * Candidate ordering, per-provider key rotation and cooldown behaviour of the fallback chain.
  * <p>
- * Time is injected rather than slept on: every assertion about a cooldown expiring runs instantly.
+ * Real providers meter quota <em>per API key, per model</em>, so {@link SimulatedProviders}
+ * does the same: it is the piece that makes "rotate the key and the model works again" a thing
+ * this test can actually observe, rather than something asserted about the configuration alone.
+ * {@code ask()} mirrors {@code AiChatServiceImpl#streamWithFailover} — walk the candidates,
+ * classify each failure, bench it, move on — so the end-to-end cases exercise the same loop
+ * production runs, without needing the whole reactive chat pipeline.
+ * <p>
+ * Time is injected rather than slept on: cooldown expiry is asserted instantly.
  */
 class AiFallbackChainTest {
 
     private static final Instant T0 = Instant.parse("2026-08-22T00:00:00Z");
+
+    private static final String GOOGLE_A = "google-key-A";
+    private static final String GOOGLE_B = "google-key-B";
+    private static final String ANTHROPIC_X = "anthropic-key-X";
+    private static final String ANTHROPIC_Y = "anthropic-key-Y";
 
     private AiProperties properties;
     private MockEnvironment environment;
     private UserChatClientResolver resolver;
     private AiFallbackChain chain;
 
-    /** The server default the deployment starts from: Google, as in the reported deployment. */
-    private ResolvedChat primary;
-
     @BeforeEach
     void setUp() {
         properties = new AiProperties();
         properties.getFallback().setEnabled(true);
-        properties.getFallback().setChain(List.of("google:gemini-3.6-flash", "anthropic:claude-haiku-4-5"));
-
         environment = new MockEnvironment();
-        environment.setProperty("spring.ai.google.genai.api-key", "google-key");
-        environment.setProperty("spring.ai.anthropic.api-key", "anthropic-key");
-
         resolver = mock(UserChatClientResolver.class);
         when(resolver.buildChatModel(any(), anyString(), any(), anyString()))
                 .thenAnswer(invocation -> mock(ChatModel.class));
-
         chain = new AiFallbackChain(properties, resolver, environment);
-
-        // Note the provider spelling: the server default arrives as Spring AI's selector name
-        // ("google-genai"), while chain entries use the AiProvider name ("GOOGLE").
-        primary = new ResolvedChat(mock(ChatModel.class), "google-genai", "gemini-2.5-flash");
     }
+
+    // ------------------------------------------------------------------ helpers
+
+    private void chain(String... entries) {
+        properties.getFallback().setChain(List.of(entries));
+    }
+
+    private void keys(AiProvider provider, String... apiKeys) {
+        Map<AiProvider, List<String>> pools =
+                new LinkedHashMap<>(properties.getFallback().getKeys());
+        pools.put(provider, Arrays.asList(apiKeys));
+        properties.getFallback().setKeys(pools);
+    }
+
+    /** The server-default model, as {@code UserChatClientResolver} hands it over. */
+    private ResolvedChat primary(String model, String apiKey) {
+        return new ResolvedChat(mock(ChatModel.class), "google-genai", model, AiKeyRef.of(apiKey));
+    }
+
+    /**
+     * A primary parked out of the way so a test can observe the chain alone.
+     * <p>
+     * Benched for a year, because a cooldown that lapsed mid-test would silently put the primary
+     * back at the head of the candidate list and quietly invalidate the assertion. The configured
+     * cooldown is restored afterwards — the expiry instant is computed when {@code trip} runs, so
+     * the long bench survives the restore.
+     */
+    private ResolvedChat benchedPrimary() {
+        ResolvedChat primary = new ResolvedChat(mock(ChatModel.class), "none", "no-primary", AiKeyRef.UNKNOWN);
+        Duration configured = properties.getFallback().getUnavailableCooldown();
+        properties.getFallback().setUnavailableCooldown(Duration.ofDays(365));
+        chain.trip(primary, Failure.MODEL_UNAVAILABLE, T0);
+        properties.getFallback().setUnavailableCooldown(configured);
+        return primary;
+    }
+
+    /** Readable "PROVIDER/model/key" rendering of a candidate list. */
+    private List<String> view(List<ResolvedChat> candidates) {
+        Map<String, String> names = Map.of(
+                AiKeyRef.of(GOOGLE_A), GOOGLE_A, AiKeyRef.of(GOOGLE_B), GOOGLE_B,
+                AiKeyRef.of(ANTHROPIC_X), ANTHROPIC_X, AiKeyRef.of(ANTHROPIC_Y), ANTHROPIC_Y);
+        return candidates.stream()
+                .map(c -> c.provider() + "/" + c.model() + "/" + names.getOrDefault(c.keyRef(), c.keyRef()))
+                .toList();
+    }
+
+    private ResolvedChat entry(AiProvider provider, String model, String apiKey) {
+        return new ResolvedChat(mock(ChatModel.class), provider.name(), model, AiKeyRef.of(apiKey));
+    }
+
+    // ------------------------------------------------------------------ ordering
 
     @Test
     @DisplayName("failover off leaves the primary as the only candidate")
     void disabledByDefault() {
         properties.getFallback().setEnabled(false);
+        chain("google:gemini-3.6-flash");
+        ResolvedChat primary = primary("gemini-2.5-flash", GOOGLE_A);
         assertThat(chain.candidates(primary)).containsExactly(primary);
     }
 
     @Test
-    @DisplayName("healthy primary leads, fallbacks follow in configured order")
-    void ordersCandidates() {
-        List<ResolvedChat> candidates = chain.candidates(primary, T0);
+    @DisplayName("a provider is exhausted across all its models and keys before the next is tried")
+    void exhaustsProviderBeforeMovingOn() {
+        chain("google:gemini-3.6-flash", "google:gemini-2.0-flash", "anthropic:claude-haiku-4-5");
+        keys(AiProvider.GOOGLE, GOOGLE_A, GOOGLE_B);
+        keys(AiProvider.ANTHROPIC, ANTHROPIC_X, ANTHROPIC_Y);
 
+        assertThat(view(chain.candidates(primary("gemini-2.5-flash", GOOGLE_A), T0))).containsExactly(
+                "google-genai/gemini-2.5-flash/google-key-A",
+                "GOOGLE/gemini-3.6-flash/google-key-A",
+                "GOOGLE/gemini-2.0-flash/google-key-A",
+                "GOOGLE/gemini-3.6-flash/google-key-B",
+                "GOOGLE/gemini-2.0-flash/google-key-B",
+                "ANTHROPIC/claude-haiku-4-5/anthropic-key-X",
+                "ANTHROPIC/claude-haiku-4-5/anthropic-key-Y");
+    }
+
+    @Test
+    @DisplayName("a model is only ever paired with a key belonging to its own provider")
+    void neverCrossesKeysBetweenProviders() {
+        chain("google:m1", "anthropic:c1");
+        keys(AiProvider.GOOGLE, GOOGLE_A, GOOGLE_B);
+        keys(AiProvider.ANTHROPIC, ANTHROPIC_X);
+
+        List<String> candidates = view(chain.candidates(benchedPrimary(), T0));
+
+        assertThat(candidates).allSatisfy(candidate -> {
+            if (candidate.startsWith("GOOGLE")) assertThat(candidate).contains("google-key");
+            if (candidate.startsWith("ANTHROPIC")) assertThat(candidate).contains("anthropic-key");
+        });
         assertThat(candidates).hasSize(3);
-        assertThat(candidates.getFirst()).isSameAs(primary);
-        assertThat(candidates.get(1).model()).isEqualTo("gemini-3.6-flash");
-        assertThat(candidates.get(2).model()).isEqualTo("claude-haiku-4-5");
+    }
+
+    // ------------------------------------------------------------------ key rotation
+
+    @Nested
+    @DisplayName("key rotation")
+    class KeyRotation {
+
+        @BeforeEach
+        void chainWithTwoGoogleKeys() {
+            chain("google:m1", "google:m2", "anthropic:c1");
+            keys(AiProvider.GOOGLE, GOOGLE_A, GOOGLE_B);
+            keys(AiProvider.ANTHROPIC, ANTHROPIC_X);
+        }
+
+        @Test
+        @DisplayName("the key is kept while any of that provider's models still has quota")
+        void keepsKeyWhileOneModelWorks() {
+            chain.trip(entry(AiProvider.GOOGLE, "m1", GOOGLE_A), Failure.QUOTA_EXHAUSTED, T0);
+
+            List<String> candidates = view(chain.candidates(benchedPrimary(), T0.plusSeconds(1)));
+
+            assertThat(candidates).contains("GOOGLE/m2/google-key-A");   // key A still in use
+            assertThat(candidates).doesNotContain("GOOGLE/m1/google-key-A");
+            assertThat(candidates).contains("GOOGLE/m1/google-key-B");   // and m1 salvaged on B
+        }
+
+        @Test
+        @DisplayName("the key rotates once every model of that provider is spent on it")
+        void rotatesKeyWhenProviderIsExhausted() {
+            chain.trip(entry(AiProvider.GOOGLE, "m1", GOOGLE_A), Failure.QUOTA_EXHAUSTED, T0);
+            chain.trip(entry(AiProvider.GOOGLE, "m2", GOOGLE_A), Failure.QUOTA_EXHAUSTED, T0);
+
+            List<String> candidates = view(chain.candidates(benchedPrimary(), T0.plusSeconds(1)));
+
+            assertThat(candidates).noneMatch(candidate -> candidate.endsWith("google-key-A"));
+            assertThat(candidates).containsExactly(
+                    "GOOGLE/m1/google-key-B", "GOOGLE/m2/google-key-B", "ANTHROPIC/c1/anthropic-key-X");
+        }
+
+        @Test
+        @DisplayName("rotating google's key does not disturb anthropic's own key choice")
+        void rotationIsPerProvider() {
+            chain.trip(entry(AiProvider.GOOGLE, "m1", GOOGLE_A), Failure.QUOTA_EXHAUSTED, T0);
+            chain.trip(entry(AiProvider.GOOGLE, "m2", GOOGLE_A), Failure.QUOTA_EXHAUSTED, T0);
+
+            assertThat(view(chain.candidates(benchedPrimary(), T0.plusSeconds(1))))
+                    .contains("ANTHROPIC/c1/anthropic-key-X");
+        }
+    }
+
+    // ------------------------------------------------------------------ end-to-end with simulated quota
+
+    /**
+     * Stands in for the provider endpoints. Quota is metered per (key, model) exactly as the free
+     * tiers charge it, so rotating a key genuinely restores a model here.
+     */
+    private static final class SimulatedProviders {
+        private final Map<String, Integer> remaining = new HashMap<>();
+        private final Set<String> retiredModels = new HashSet<>();
+        private final Set<String> revokedKeys = new HashSet<>();
+        private final List<String> calls = new ArrayList<>();
+
+        void allow(String apiKey, String model, int callCount) {
+            remaining.put(AiKeyRef.of(apiKey) + "|" + model, callCount);
+        }
+
+        /** Answer, or throw what that provider would throw. */
+        String call(ResolvedChat candidate) {
+            String id = candidate.provider() + "|" + candidate.keyRef() + "|" + candidate.model();
+            calls.add(id);
+            if (revokedKeys.contains(candidate.keyRef())) {
+                throw wrapped("401 . API key not valid. Please pass a valid API key.");
+            }
+            if (retiredModels.contains(candidate.model())) {
+                throw wrapped("404 . This model models/" + candidate.model()
+                        + " is no longer available to new users.");
+            }
+            String quotaKey = candidate.keyRef() + "|" + candidate.model();
+            Integer left = remaining.get(quotaKey);
+            if (left != null) {
+                if (left <= 0) {
+                    throw wrapped("429 . RESOURCE_EXHAUSTED. You exceeded your current quota.");
+                }
+                remaining.put(quotaKey, left - 1);
+            }
+            return id;
+        }
+
+        /** Spring AI wraps every provider failure in a generic runtime exception. */
+        private static RuntimeException wrapped(String providerMessage) {
+            return new RuntimeException("Failed to generate content", new RuntimeException(providerMessage));
+        }
+
+        long callsMatching(String fragment) {
+            return calls.stream().filter(call -> call.contains(fragment)).count();
+        }
+    }
+
+    private final SimulatedProviders providers = new SimulatedProviders();
+
+    /** One chat request, mirroring {@code AiChatServiceImpl#streamWithFailover}. */
+    private String ask(ResolvedChat primary, Instant now) {
+        for (ResolvedChat candidate : chain.candidates(primary, now)) {
+            try {
+                return providers.call(candidate);
+            } catch (RuntimeException e) {
+                Failure failure = AiFailoverPolicy.classify(e);
+                chain.trip(candidate, failure, now);
+                if (!failure.shouldFailover()) {
+                    return "ERROR:" + e.getCause().getMessage();
+                }
+            }
+        }
+        return "NO_CANDIDATE";
     }
 
     @Test
-    @DisplayName("a benched model is skipped, so later requests stop paying for its failure")
-    void skipsCoolingDownPrimary() {
-        chain.trip(primary, Failure.QUOTA_EXHAUSTED, T0);
+    @DisplayName("requests drain the first key's models, rotate to the second, then change provider")
+    void drainsKeysThenProviders() {
+        chain("google:m1", "google:m2", "anthropic:c1");
+        keys(AiProvider.GOOGLE, GOOGLE_A, GOOGLE_B);
+        keys(AiProvider.ANTHROPIC, ANTHROPIC_X);
+        ResolvedChat primary = benchedPrimary();
 
-        List<ResolvedChat> candidates = chain.candidates(primary, T0.plusSeconds(60));
+        // Free-tier shape: one call per (key, model) on Google; Anthropic is plentiful.
+        providers.allow(GOOGLE_A, "m1", 1);
+        providers.allow(GOOGLE_A, "m2", 1);
+        providers.allow(GOOGLE_B, "m1", 1);
+        providers.allow(GOOGLE_B, "m2", 1);
 
-        assertThat(candidates).doesNotContain(primary);
-        assertThat(candidates.getFirst().model()).isEqualTo("gemini-3.6-flash");
+        List<String> answers = new ArrayList<>();
+        for (int request = 0; request < 6; request++) {
+            answers.add(ask(primary, T0.plusSeconds(10 + request)));
+        }
+
+        assertThat(answers).containsExactly(
+                "GOOGLE|" + AiKeyRef.of(GOOGLE_A) + "|m1",
+                "GOOGLE|" + AiKeyRef.of(GOOGLE_A) + "|m2",
+                "GOOGLE|" + AiKeyRef.of(GOOGLE_B) + "|m1",
+                "GOOGLE|" + AiKeyRef.of(GOOGLE_B) + "|m2",
+                "ANTHROPIC|" + AiKeyRef.of(ANTHROPIC_X) + "|c1",
+                "ANTHROPIC|" + AiKeyRef.of(ANTHROPIC_X) + "|c1");
     }
 
     @Test
-    @DisplayName("a quota cooldown expires on its own and the model returns to rotation")
-    void quotaCooldownExpires() {
+    @DisplayName("a spent quota costs one failing call in total, not one per request")
+    void benchingStopsRepeatedFailingCalls() {
+        chain("google:m1", "anthropic:c1");
+        keys(AiProvider.GOOGLE, GOOGLE_A);
+        keys(AiProvider.ANTHROPIC, ANTHROPIC_X);
+        ResolvedChat primary = benchedPrimary();
+        providers.allow(GOOGLE_A, "m1", 0);      // already out of quota
+
+        for (int request = 0; request < 5; request++) {
+            ask(primary, T0.plusSeconds(10 + request));
+        }
+
+        assertThat(providers.callsMatching("|m1")).isEqualTo(1);
+        assertThat(providers.callsMatching("|c1")).isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("a cooldown expires on its own and the key returns to rotation")
+    void cooldownExpiryReturnsKeyToRotation() {
+        chain("google:m1", "anthropic:c1");
+        keys(AiProvider.GOOGLE, GOOGLE_A);
+        keys(AiProvider.ANTHROPIC, ANTHROPIC_X);
         properties.getFallback().setQuotaCooldown(Duration.ofMinutes(5));
-        chain.trip(primary, Failure.QUOTA_EXHAUSTED, T0);
+        ResolvedChat primary = benchedPrimary();
+        providers.allow(GOOGLE_A, "m1", 1);
 
-        assertThat(chain.candidates(primary, T0.plusSeconds(299))).doesNotContain(primary);
-        assertThat(chain.candidates(primary, T0.plusSeconds(301)).getFirst()).isSameAs(primary);
+        assertThat(ask(primary, T0.plusSeconds(10))).contains("|m1");
+        assertThat(ask(primary, T0.plusSeconds(11))).contains("|c1");   // google now spent
+
+        providers.allow(GOOGLE_A, "m1", 1);                             // provider window refilled
+        assertThat(ask(primary, T0.plusSeconds(120))).contains("|c1");  // still benched
+        assertThat(ask(primary, T0.plusSeconds(700))).contains("|m1");  // cooldown served
     }
 
     @Test
-    @DisplayName("a retired model is benched far longer than a spent quota")
-    void retiredModelGetsTheLongCooldown() {
-        properties.getFallback().setQuotaCooldown(Duration.ofMinutes(5));
-        properties.getFallback().setUnavailableCooldown(Duration.ofHours(6));
+    @DisplayName("a retired model is benched after one 404 and the next model answers")
+    void retiredModelIsBenchedAfterOneAttempt() {
+        chain("google:m1", "google:m2");
+        keys(AiProvider.GOOGLE, GOOGLE_A, GOOGLE_B);
+        ResolvedChat primary = benchedPrimary();
+        providers.retiredModels.add("m1");
 
-        chain.trip(primary, Failure.MODEL_UNAVAILABLE, T0);
-
-        // Well past the quota cooldown, still benched — a 404 model is not coming back by itself.
-        assertThat(chain.candidates(primary, T0.plusSeconds(3600))).doesNotContain(primary);
-        assertThat(chain.candidates(primary, T0.plus(Duration.ofHours(7))).getFirst()).isSameAs(primary);
+        assertThat(ask(primary, T0.plusSeconds(10))).endsWith("|m2");
+        assertThat(providers.callsMatching("|m1")).isEqualTo(1);
     }
 
     @Test
-    @DisplayName("a credential failure never benches a model")
-    void doesNotBenchOnAuthFailure() {
-        chain.trip(primary, Failure.NOT_FAILOVER, T0);
-        assertThat(chain.candidates(primary, T0).getFirst()).isSameAs(primary);
+    @DisplayName("a revoked key surfaces as an error instead of quietly rotating to the next one")
+    void revokedKeyDoesNotFailOver() {
+        chain("google:m1");
+        keys(AiProvider.GOOGLE, GOOGLE_A, GOOGLE_B);
+        ResolvedChat primary = benchedPrimary();
+        providers.revokedKeys.add(AiKeyRef.of(GOOGLE_A));
+
+        assertThat(ask(primary, T0.plusSeconds(10))).startsWith("ERROR:401");
+        // Not benched either — the operator must keep seeing the real error until they fix the key.
+        assertThat(view(chain.candidates(primary, T0.plusSeconds(11)))).contains("GOOGLE/m1/google-key-A");
+    }
+
+    // ------------------------------------------------------------------ configuration handling
+
+    @Test
+    @DisplayName("a provider with no pool keeps using its single spring.ai.*.api-key")
+    void emptyPoolFallsBackToTheServerKey() {
+        chain("google:m1");
+        environment.setProperty("spring.ai.google.genai.api-key", "legacy-single-key");
+
+        List<ResolvedChat> candidates = chain.candidates(benchedPrimary(), T0);
+
+        assertThat(candidates).hasSize(1);
+        assertThat(candidates.getFirst().keyRef()).isEqualTo(AiKeyRef.of("legacy-single-key"));
     }
 
     @Test
-    @DisplayName("the primary is retried rather than refused when everything is cooling down")
-    void fallsBackToPrimaryWhenAllBenched() {
-        properties.getFallback().setChain(List.of("google:gemini-3.6-flash"));
-        List<ResolvedChat> candidates = chain.candidates(primary, T0);
-        chain.trip(primary, Failure.QUOTA_EXHAUSTED, T0);
-        chain.trip(candidates.get(1), Failure.QUOTA_EXHAUSTED, T0);
+    @DisplayName("the 'disabled' sentinel counts as no key at all")
+    void disabledSentinelYieldsNoCandidates() {
+        chain("google:m1");
+        environment.setProperty("spring.ai.google.genai.api-key", "disabled");
+        ResolvedChat primary = benchedPrimary();
 
-        assertThat(chain.candidates(primary, T0.plusSeconds(60))).containsExactly(primary);
+        // No usable chain candidate: the primary is handed back rather than nothing at all, so the
+        // request fails with a real provider error instead of a synthetic "no model" one.
+        assertThat(chain.candidates(primary, T0)).containsExactly(primary);
     }
 
     @Test
-    @DisplayName("chain entries needing an unconfigured API key are skipped, not fatal")
-    void skipsProvidersWithoutApiKey() {
-        environment.setProperty("spring.ai.openai.api-key", "disabled");  // the application.yml sentinel
-        properties.getFallback().setChain(List.of("openai:gpt-4o-mini", "anthropic:claude-haiku-4-5"));
+    @DisplayName("blank, null and duplicate pool entries are cleaned up")
+    void cleansUpThePool() {
+        chain("google:m1");
+        keys(AiProvider.GOOGLE, GOOGLE_A, "   ", GOOGLE_A, null, GOOGLE_B);
 
-        List<ResolvedChat> candidates = chain.candidates(primary, T0);
+        assertThat(view(chain.candidates(benchedPrimary(), T0)))
+                .containsExactly("GOOGLE/m1/google-key-A", "GOOGLE/m1/google-key-B");
+    }
 
-        assertThat(candidates).hasSize(2);
-        assertThat(candidates.get(1).model()).isEqualTo("claude-haiku-4-5");
+    @Test
+    @DisplayName("the primary is not offered twice when the chain names the same model and key")
+    void deduplicatesPrimaryAgainstTheChain() {
+        chain("google:gemini-3.6-flash");
+        keys(AiProvider.GOOGLE, GOOGLE_A);
+
+        ResolvedChat primary = primary("gemini-3.6-flash", GOOGLE_A);
+
+        assertThat(chain.candidates(primary, T0)).containsExactly(primary);
     }
 
     @Test
     @DisplayName("malformed and unknown chain entries are ignored without breaking the chain")
     void ignoresMalformedEntries() {
-        properties.getFallback().setChain(List.of("", "no-separator", "mystery:model", "anthropic:claude-haiku-4-5"));
+        chain("", "no-separator", "mystery:model", "anthropic:c1");
+        keys(AiProvider.ANTHROPIC, ANTHROPIC_X);
 
-        List<ResolvedChat> candidates = chain.candidates(primary, T0);
-
-        assertThat(candidates).hasSize(2);
-        assertThat(candidates.get(1).model()).isEqualTo("claude-haiku-4-5");
+        assertThat(view(chain.candidates(benchedPrimary(), T0)))
+                .containsExactly("ANTHROPIC/c1/anthropic-key-X");
     }
 
     @Test
-    @DisplayName("the primary is not offered twice when the chain also lists it")
-    void deduplicatesPrimary() {
-        // Same model as the primary, spelled with the AiProvider name instead of the selector name.
-        properties.getFallback().setChain(List.of("google:gemini-2.5-flash", "anthropic:claude-haiku-4-5"));
+    @DisplayName("a provider client that refuses to build is skipped, not fatal")
+    void survivesAClientThatCannotBeBuilt() {
+        chain("google:m1", "anthropic:c1");
+        keys(AiProvider.GOOGLE, GOOGLE_A);
+        keys(AiProvider.ANTHROPIC, ANTHROPIC_X);
+        when(resolver.buildChatModel(eq(AiProvider.GOOGLE), anyString(), any(), anyString()))
+                .thenThrow(new IllegalStateException("no credentials"));
 
-        List<ResolvedChat> candidates = chain.candidates(primary, T0);
+        assertThat(view(chain.candidates(benchedPrimary(), T0)))
+                .containsExactly("ANTHROPIC/c1/anthropic-key-X");
+    }
 
-        assertThat(candidates).hasSize(2);
-        assertThat(candidates.getFirst()).isSameAs(primary);
-        assertThat(candidates.get(1).model()).isEqualTo("claude-haiku-4-5");
+    @Test
+    @DisplayName("the primary is retried rather than refused when everything is cooling down")
+    void fallsBackToPrimaryWhenAllBenched() {
+        chain("google:m1");
+        keys(AiProvider.GOOGLE, GOOGLE_A);
+        ResolvedChat primary = primary("gemini-3.6-flash", GOOGLE_A);
+
+        chain.trip(primary, Failure.QUOTA_EXHAUSTED, T0);
+        chain.trip(entry(AiProvider.GOOGLE, "m1", GOOGLE_A), Failure.QUOTA_EXHAUSTED, T0);
+
+        assertThat(chain.candidates(primary, T0.plusSeconds(60))).containsExactly(primary);
+    }
+
+    // ------------------------------------------------------------------ cooldown semantics
+
+    @Test
+    @DisplayName("a retired model is benched far longer than a spent quota")
+    void retiredModelGetsTheLongCooldown() {
+        chain("google:m1");
+        keys(AiProvider.GOOGLE, GOOGLE_A);
+        properties.getFallback().setQuotaCooldown(Duration.ofMinutes(5));
+        properties.getFallback().setUnavailableCooldown(Duration.ofHours(6));
+        ResolvedChat primary = benchedPrimary();
+
+        chain.trip(entry(AiProvider.GOOGLE, "m1", GOOGLE_A), Failure.MODEL_UNAVAILABLE, T0);
+
+        // Well past the quota cooldown, still benched — a 404 model does not come back by itself.
+        assertThat(chain.candidates(primary, T0.plusSeconds(3600))).containsExactly(primary);
+        assertThat(view(chain.candidates(primary, T0.plus(Duration.ofHours(7)))))
+                .containsExactly("GOOGLE/m1/google-key-A");
+    }
+
+    @Test
+    @DisplayName("a credential failure never benches anything")
+    void authFailureDoesNotBench() {
+        chain("google:m1");
+        keys(AiProvider.GOOGLE, GOOGLE_A);
+        ResolvedChat primary = benchedPrimary();
+
+        chain.trip(entry(AiProvider.GOOGLE, "m1", GOOGLE_A), Failure.NOT_FAILOVER, T0);
+
+        assertThat(view(chain.candidates(primary, T0))).containsExactly("GOOGLE/m1/google-key-A");
+    }
+
+    @Test
+    @DisplayName("two BYOK users on the same provider and model do not share a cooldown")
+    void byokUsersHaveIndependentCooldowns() {
+        ResolvedChat userOne = entry(AiProvider.GOOGLE, "gemini-3.6-flash", "user-one-key");
+        ResolvedChat userTwo = entry(AiProvider.GOOGLE, "gemini-3.6-flash", "user-two-key");
+
+        chain.trip(userOne, Failure.QUOTA_EXHAUSTED, T0);
+
+        assertThat(chain.isHealthy(
+                AiFallbackChain.cooldownKey("GOOGLE", userOne.keyRef(), "gemini-3.6-flash"), T0.plusSeconds(1)))
+                .isFalse();
+        assertThat(chain.isHealthy(
+                AiFallbackChain.cooldownKey("GOOGLE", userTwo.keyRef(), "gemini-3.6-flash"), T0.plusSeconds(1)))
+                .isTrue();
     }
 
     @Test
     @DisplayName("provider spelling differences resolve to the same cooldown entry")
     void normalisesProviderSpelling() {
-        assertThat(AiFallbackChain.key("google-genai", "gemini-3.6-flash"))
-                .isEqualTo(AiFallbackChain.key("GOOGLE", "Gemini-3.6-Flash"));
+        assertThat(AiFallbackChain.cooldownKey("google-genai", "ref", "gemini-3.6-flash"))
+                .isEqualTo(AiFallbackChain.cooldownKey("GOOGLE", "ref", "Gemini-3.6-Flash"));
+    }
+
+    @Test
+    @DisplayName("a fingerprint identifies a key without revealing it")
+    void fingerprintsDoNotLeakKeys() {
+        String fingerprint = AiKeyRef.of("AIzaSy-super-secret-key");
+
+        assertThat(fingerprint).doesNotContain("AIzaSy", "secret").hasSize(8);
+        assertThat(fingerprint).isEqualTo(AiKeyRef.of("AIzaSy-super-secret-key"));
+        assertThat(fingerprint).isNotEqualTo(AiKeyRef.of("AIzaSy-super-secret-kez"));
+        assertThat(AiKeyRef.of("  ")).isEqualTo(AiKeyRef.UNKNOWN);
+        assertThat(AiKeyRef.of(null)).isEqualTo(AiKeyRef.UNKNOWN);
     }
 }

--- a/openfilz-api/src/test/java/org/openfilz/dms/service/impl/AiRagAccessFilterTest.java
+++ b/openfilz-api/src/test/java/org/openfilz/dms/service/impl/AiRagAccessFilterTest.java
@@ -10,6 +10,7 @@ import org.openfilz.dms.service.DocumentService;
 import org.openfilz.dms.service.StorageService;
 import org.openfilz.dms.service.ai.AiAccessPolicy;
 import org.openfilz.dms.service.ai.AiDocumentQueryService;
+import org.openfilz.dms.service.ai.AiFallbackChain;
 import org.openfilz.dms.service.ai.ChatClientAssembler;
 import org.openfilz.dms.service.ai.DocumentAiTools;
 import org.openfilz.dms.service.ai.DocumentAiToolsFactory;
@@ -57,6 +58,7 @@ class AiRagAccessFilterTest {
     private AiChatServiceImpl service(AiAccessPolicy policy) {
         return new AiChatServiceImpl(
                 mock(UserChatClientResolver.class),
+                mock(AiFallbackChain.class),
                 mock(ChatClientAssembler.class),
                 mock(DocumentAiToolsFactory.class),
                 vectorStore,


### PR DESCRIPTION
Started as a deployment fix for a live AI-enabled deployment that could not start, and grew into the quota resilience that failure exposed.

## 1. `fix(deploy)` — the pgvector image override was silently defeated

`openfilz-api` crash-looped on `V1_4__add_ai_support.sql` with:

```
ERROR: extension "vector" is not available
```

`docker-compose.ai.yml` overrode the postgres image with `${POSTGRES_IMAGE:-pgvector/pgvector:pg17}` — but both `.env.example` templates *set* `POSTGRES_IMAGE` to a plain image. `${VAR:-default}` only falls back when `VAR` is unset, so any `.env` copied from the template defeated the override and postgres came up without the `vector` extension.

- The AI overlay now reads a dedicated `POSTGRES_AI_IMAGE`, so a base image pinned for a non-AI deployment can no longer defeat it.
- Both `.env.example` files leave the pin commented out instead of overriding the compose files' own correct defaults.
- Documented the AI overlay in the docker-compose README, with a troubleshooting entry for this exact error.

Verified with `docker compose config`: with `POSTGRES_IMAGE=postgres:17` set, the AI overlay still resolves to `pgvector/pgvector:pg17`.

## 2. `docs(deploy/dokploy)` — the `COMPOSE_PROFILES` gotcha

`compose.yaml` gates `ollama`/`ollama-init` with a profile-name-is-the-boolean trick (`profiles: ["${OLLAMA_CHAT_ENABLED:-false}", …]`). Compose only starts a service whose profile is listed in `COMPOSE_PROFILES`, so setting `OLLAMA_*_ENABLED=true` alone never creates the container and the API fails with `ollama: Temporary failure in name resolution`. None of the AI variables were in `dokploy/.env.example` at all; they are now, with that requirement spelled out.

## 3. `feat(ai)` — failover when the active chat model stops answering

The same deployment then hit:

```
404 . This model models/gemini-2.5-flash is no longer available to new users.
```

Google retires model ids, and free tiers run out of quota mid-afternoon — either way AI Document Chat goes down. Adds opt-in failover (`openfilz.ai.fallback.enabled`, **off by default**, so existing deployments are unchanged):

```
AI_FALLBACK_ENABLED=true
AI_FALLBACK_CHAIN=google:gemini-3.6-flash,anthropic:claude-haiku-4-5,openai:gpt-4o-mini
```

Two mechanisms, both needed:

| | |
|---|---|
| **Failover** | The request that hit the quota is retried on the next candidate, so the user still gets an answer. |
| **Cooldown** | The failed model is benched, so *following* requests skip it instead of each paying a failing round-trip. Without this a spent **daily** quota adds a failing call to every request for the rest of the day. Cooldowns expire unattended. |

`AiFailoverPolicy` classifies failures without referencing any provider SDK type — Spring AI wraps everything in `RuntimeException("Failed to generate content")`, and compiling against (or reflecting over) `com.google.genai.errors.*` would fight GraalVM. It walks the cause chain matching HTTP status, exception type name and message keywords.

Also updates the Gemini default from the now-retired `gemini-2.5-flash` to `gemini-3.6-flash`.

## 4. `feat(ai)` — per-provider API key pools

Quota is charged **per API key**, per model, so one key per provider capped the whole chain. A second key is a second allowance:

```
AI_FALLBACK_KEYS_GOOGLE=AIza-first-project,AIza-second-project
```

A provider is exhausted completely — every chain model on every key — before the next provider is touched:

```
google:     m1/keyA  m2/keyA  m1/keyB  m2/keyB
anthropic:  c1/keyX  c1/keyY
```

So the key rotates exactly when the provider has nothing left on the current one, and moving to another provider picks up that provider's own keys. Which key is "current" is *derived* from the cooldown registry rather than held in a pointer, so a spent key drops out and rejoins when its cooldowns lapse, with no stored index to get stuck.

This also fixes a latent bug: cooldowns were keyed `(provider, model)`, so two BYOK users on the same provider and model shared one bucket — one user's exhausted quota benched the model for everyone. They are now keyed `(provider, key, model)`.

Keys never reach cooldown maps, cache keys or logs: `AiKeyRef` reduces each to an 8-hex-char SHA-256 fingerprint.

### Deliberate limits

- **A credential failure never fails over.** Quietly answering from another model would hide a broken API key. `401`/`403` still surface as errors.
- **No retry once tokens have streamed** (would splice two answers together) **or once a tool has mutated something** (a retried move/rename/delete would run twice). Quota and 404 failures both arrive before the first token.
- **Chain entries are API-key providers only** (`google`, `anthropic`, `openai`, `openai-compatible`), reusing the existing BYOK `buildChatModel` path. Ollama is excluded: local, no quota, built by auto-configuration.

## Testing

`AiFailoverPolicyTest` — classification against the real message shapes each provider emits, including the verbatim production 404; guards proving digits in model names (`gpt-4.1-mini-2025-04-14`) are not read as HTTP statuses; cyclic and over-deep cause chains.

`AiFallbackChainTest` — a `SimulatedProviders` double meters quota per `(key, model)` exactly as the real tiers do, and `ask()` mirrors `streamWithFailover`, so rotation is observed **end-to-end over a sequence of requests** rather than asserted about configuration. Covers provider-grouped ordering, key retained while any model still has quota, rotation once all are spent, no cross-provider key leakage, one failing call per spent quota rather than one per request, unattended cooldown expiry, retired models, revoked keys surfacing instead of rotating, pool hygiene, primary de-duplication, per-user BYOK cooldown isolation, and fingerprint opacity.

> **Reviewer note.** The compose/`docker compose config` checks were run. The Java was **not compiled in my environment** — it has JDK 21 and the project needs 25, with no populated `~/.m2`. To compensate, `AiFailoverPolicy` (dependency-free) and the real `AiFallbackChain` source were compiled and executed standalone against stubs — 21/21 and 30/30 assertions green, which is how the candidate-ordering flaw in §4 and three wrong test expectations were caught. Everything else is hand-reviewed. Note also that no workflow runs on `pull_request`, so this PR will show no checks; `Build Backend with Maven` only runs on push to `develop`.

---
_Generated by [Claude Code](https://claude.ai/code/session_013KV23y5acwYwbhFLEa4DhK)_