### PR TITLE
fix(ai): survive a refused API key in a fallback pool, and repair typed-exception classification

### DIFF
--- a/deploy/docker-compose/dokploy/.env.example
+++ b/deploy/docker-compose/dokploy/.env.example
@@ -157,8 +157,9 @@ STORAGE_TYPE=local
 # Free tiers hand out small per-minute/per-day allowances. With this on, a chat that fails
 # because the quota is spent (or the model was retired, or the provider is down) is retried
 # on the next model in the chain, and the failed model is benched for a cooldown so the
-# requests after it skip straight to one that works. A bad API key never triggers failover —
-# that surfaces as an error so you fix the key rather than silently answering elsewhere.
+# requests after it skip straight to one that works. A bad API key on the model you chose never
+# triggers failover — that surfaces as an error so you fix the key rather than silently answering
+# elsewhere. (A key from the pools below is the exception: see AI_FALLBACK_KEYS_* .)
 # Entries are 'provider:model' (google|anthropic|openai|openai-compatible), tried in order;
 # each needs its API key set above. The active model is tried first and needs no entry.
 # A provider named in the chain needs NO <PROVIDER>_CHAT_ENABLED switch, and when no switch is
@@ -174,6 +175,10 @@ STORAGE_TYPE=local
 # once every chain model of a provider is spent on the key in use, the next key of that provider
 # takes over and those models work again — the cheapest way to widen a free-tier allowance.
 # A provider left empty here keeps using its single API key above.
+# A pool key the provider REFUSES (401/403) is dropped from rotation for the rest of the process
+# and the next key takes over — one bad key must not break chat when you configured several. It is
+# logged at ERROR with a short fingerprint of the key so you know which entry to fix; the key is
+# not retried until you correct it here and restart.
 #AI_FALLBACK_KEYS_GOOGLE=AIza-first-project-key,AIza-second-project-key
 #AI_FALLBACK_KEYS_ANTHROPIC=
 #AI_FALLBACK_KEYS_OPENAI=

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -620,11 +620,27 @@ Watch for these in the logs:
 > local model going down is an outage to fix, not something to route around. (A BYOK user who
 > chose a cloud provider themselves still gets failover.)
 
-> **A bad API key never triggers failover.** Quietly answering from a different model would hide a
-> broken credential instead of surfacing it, so authentication and malformed-request errors are
-> still returned as errors. Failover is also abandoned if the model already streamed part of an
-> answer, or if a tool already moved/renamed/deleted something — retrying either would show the
-> user a spliced answer or repeat the action.
+> **A bad API key never reroutes the model you chose.** When the provider refuses the credentials
+> of the model actually in use — the server default, or a BYOK user's own — the error is returned
+> as an error: quietly answering from somewhere else would hide a broken credential instead of
+> surfacing it. Malformed requests are treated the same way.
+>
+> **A refused key from a *pool* is dropped instead.** `AI_FALLBACK_KEYS_<PROVIDER>` exists so that
+> one key failing is survivable, so a key the provider rejects is removed from rotation for the
+> rest of the process and the next key takes over. It is not silent: it is logged at ERROR with
+> the key's fingerprint, and the key is not retried until you fix it and restart.
+>
+> ```
+> [AI] GOOGLE rejected the fallback API key c59be430 — dropping it from the pool for the rest of
+> this process; fix or remove it in AI_FALLBACK_KEYS_GOOGLE
+> ```
+>
+> The fingerprint is a short hash of the key, never the key itself — it identifies *which* entry of
+> the pool to fix without putting a secret in the logs.
+
+> **Failover is abandoned mid-answer.** If the model already streamed part of a response, or a tool
+> already moved/renamed/deleted something, the error propagates rather than retrying — the user
+> would otherwise see a spliced answer or have the action repeated.
 
 #### Getting an API key
 

--- a/openfilz-api/src/main/java/org/openfilz/dms/service/ai/AiFailoverPolicy.java
+++ b/openfilz-api/src/main/java/org/openfilz/dms/service/ai/AiFailoverPolicy.java
@@ -17,9 +17,13 @@ import java.util.regex.Pattern;
  * any of those types. So classification walks the cause chain and matches on HTTP status,
  * exception simple name, and message keywords only.
  * <p>
- * The one failure kind that deliberately does <em>not</em> fail over is a credential problem:
- * silently answering with a different model when an API key is wrong or revoked would hide a
- * misconfiguration that an operator has to fix. Those surface to the caller as before.
+ * A credential problem is reported as its own verdict, {@link Failure#CREDENTIALS_REJECTED},
+ * rather than folded into {@link Failure#NOT_FAILOVER}: what to do about a refused key depends on
+ * <em>whose</em> key it is. The active model's key must surface — silently answering elsewhere
+ * would hide a misconfiguration an operator has to fix. A key from a fallback pool is the opposite
+ * case: the pool exists so that one key failing is survivable, so the caller disables that key and
+ * keeps going (see {@code AiChatServiceImpl}). Neither is decided here; this class only names the
+ * failure.
  */
 public final class AiFailoverPolicy {
 
@@ -38,7 +42,15 @@ public final class AiFailoverPolicy {
         /** 5xx, connection failures, timeouts — the provider is down or unreachable. Retry elsewhere. */
         PROVIDER_OVERLOADED(true),
 
-        /** Bad credentials, malformed request, or an OpenFilz bug — surface it, never mask it. */
+        /**
+         * The provider refused the API key itself (401/403 with no quota wording, or a typed
+         * authentication exception). Another <em>model</em> on the same key would fail
+         * identically, so {@link #shouldFailover()} is false; another <em>key</em> may well
+         * work, which is the caller's decision to make.
+         */
+        CREDENTIALS_REJECTED(false),
+
+        /** A malformed request or an OpenFilz bug — surface it, never mask it. */
         NOT_FAILOVER(false);
 
         private final boolean failover;
@@ -109,17 +121,24 @@ public final class AiFailoverPolicy {
      * <p>
      * The whole cause chain is inspected because Spring AI wraps provider exceptions in a
      * generic {@code RuntimeException}: the actionable signal is always further down. The first
-     * cause that yields a verdict other than {@link Failure#NOT_FAILOVER} wins, so a definite
-     * "429" deep in the chain is not masked by an uninformative wrapper at the top.
+     * cause that yields one of the three retryable verdicts wins, so a definite "429" deep in the
+     * chain is not masked by an uninformative wrapper at the top.
+     * <p>
+     * {@link Failure#CREDENTIALS_REJECTED} is the weakest verdict: it is remembered but does not
+     * stop the walk. Provider messages mention "API key" freely — a retired-model or quota error
+     * often does — and letting that wording short-circuit would turn a spent quota into a
+     * "your key is broken" verdict, which now has the side effect of disabling a pool key.
      */
     public static Failure classify(Throwable error) {
         Failure verdict = Failure.NOT_FAILOVER;
         Throwable current = error;
         for (int depth = 0; current != null && depth < MAX_CAUSE_DEPTH; depth++) {
             Failure found = classifySingle(current);
-            if (found != Failure.NOT_FAILOVER) {
+            if (found.shouldFailover()) {
+                return found;
+            }
+            if (found == Failure.CREDENTIALS_REJECTED && verdict == Failure.NOT_FAILOVER) {
                 verdict = found;
-                break;
             }
             Throwable cause = current.getCause();
             current = (cause == current) ? null : cause;
@@ -134,7 +153,7 @@ public final class AiFailoverPolicy {
 
         // Typed exceptions are unambiguous — prefer them over message archaeology.
         if (containsAny(type, QUOTA_TYPES)) return Failure.QUOTA_EXHAUSTED;
-        if (containsAny(type, AUTH_TYPES)) return Failure.NOT_FAILOVER;
+        if (containsAny(type, AUTH_TYPES)) return Failure.CREDENTIALS_REJECTED;
         if (containsAny(type, MODEL_GONE_TYPES)) return Failure.MODEL_UNAVAILABLE;
         if (containsAny(type, OVERLOAD_TYPES)) return Failure.PROVIDER_OVERLOADED;
 
@@ -145,7 +164,7 @@ public final class AiFailoverPolicy {
                 // Some providers report an exhausted quota as 402/403 rather than 429, so the
                 // message still decides; without quota wording these stay a credential problem.
                 case 401, 402, 403 -> containsAny(message, QUOTA_KEYWORDS)
-                        ? Failure.QUOTA_EXHAUSTED : Failure.NOT_FAILOVER;
+                        ? Failure.QUOTA_EXHAUSTED : Failure.CREDENTIALS_REJECTED;
                 case 404 -> Failure.MODEL_UNAVAILABLE;
                 case 408, 500, 502, 503, 504, 529 -> Failure.PROVIDER_OVERLOADED;
                 // Any other recognised status is a request we built wrong — our bug, not the
@@ -155,7 +174,7 @@ public final class AiFailoverPolicy {
         }
 
         if (containsAny(message, QUOTA_KEYWORDS)) return Failure.QUOTA_EXHAUSTED;
-        if (containsAny(message, AUTH_KEYWORDS)) return Failure.NOT_FAILOVER;
+        if (containsAny(message, AUTH_KEYWORDS)) return Failure.CREDENTIALS_REJECTED;
         if (containsAny(message, MODEL_GONE_KEYWORDS)) return Failure.MODEL_UNAVAILABLE;
         if (containsAny(message, OVERLOAD_KEYWORDS)) return Failure.PROVIDER_OVERLOADED;
         return Failure.NOT_FAILOVER;
@@ -182,10 +201,16 @@ public final class AiFailoverPolicy {
         return null;
     }
 
+    /**
+     * Case-insensitive on <em>both</em> sides: the keyword tables are lower case but the type
+     * tables are CamelCase, and comparing a lower-cased class name against {@code "RateLimit"}
+     * silently never matches — which would quietly reduce every typed-exception rule above to
+     * dead code and leave classification to message archaeology alone.
+     */
     private static boolean containsAny(String haystack, String[] needles) {
         String lower = haystack.toLowerCase(Locale.ROOT);
         for (String needle : needles) {
-            if (lower.contains(needle)) return true;
+            if (lower.contains(needle.toLowerCase(Locale.ROOT))) return true;
         }
         return false;
     }

--- a/openfilz-api/src/main/java/org/openfilz/dms/service/ai/AiFallbackChain.java
+++ b/openfilz-api/src/main/java/org/openfilz/dms/service/ai/AiFallbackChain.java
@@ -254,6 +254,48 @@ public class AiFallbackChain {
     }
 
     /**
+     * Take a whole API key out of rotation because the provider refused it.
+     * <p>
+     * Unlike a spent quota this has no cooldown: a key the provider rejects is a configuration
+     * error, and it will keep being rejected until an operator changes it — at which point the
+     * process restarts anyway and the registry is empty again. Every model already built on that
+     * key is dropped with it, since they all carry the same refused credential.
+     * <p>
+     * Reserved for keys that came from a <em>pool</em>: refusing the active model's own key is
+     * reported to the caller instead, so a single-key deployment cannot be silently rerouted.
+     *
+     * @return true when this call is what disabled the key (so the caller logs it once)
+     */
+    public boolean disableKey(ResolvedChat chat) {
+        String providerKey = providerKey(chat);
+        if (providerKey == null) {
+            return false;   // nothing identifiable to disable — do not bench an unrelated key
+        }
+        if (!unusable.add(providerKey)) {
+            return false;   // already disabled by this or a concurrent request
+        }
+        models.keySet().removeIf(modelKey -> modelKey.startsWith(providerKey + ':'));
+        return true;
+    }
+
+    /**
+     * Whether this candidate's key is still in rotation. The candidate list of a request is built
+     * once, up front, so a key disabled part-way through it is still listed for that request —
+     * the caller checks this before each attempt to avoid paying one refused call per model.
+     */
+    public boolean isUsable(ResolvedChat chat) {
+        String providerKey = providerKey(chat);
+        return providerKey == null || !unusable.contains(providerKey);
+    }
+
+    /** {@code provider:keyRef} for a resolved model, or null when its key has no fingerprint. */
+    private static String providerKey(ResolvedChat chat) {
+        String keyRef = chat.keyRef();
+        if (keyRef == null || keyRef.isBlank() || AiKeyRef.UNKNOWN.equals(keyRef)) return null;
+        return canonicalProvider(chat.provider()) + ':' + keyRef;
+    }
+
+    /**
      * Record that a candidate just failed, so subsequent requests skip that (model, key) pair
      * until its cooldown expires. A retired model gets the longer cooldown — unlike a spent quota
      * it will not come back.

--- a/openfilz-api/src/main/java/org/openfilz/dms/service/impl/AiChatServiceImpl.java
+++ b/openfilz-api/src/main/java/org/openfilz/dms/service/impl/AiChatServiceImpl.java
@@ -39,6 +39,7 @@ import reactor.core.scheduler.Schedulers;
 import java.time.OffsetDateTime;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -131,7 +132,7 @@ public class AiChatServiceImpl implements AiChatService {
                             StringBuilder fullResponse = new StringBuilder();
 
                             log.debug("[AI] Sending prompt to LLM (streaming)...");
-                            return streamWithFailover(candidates, 0, tools, history, augmentedMessage, fullResponse)
+                            return streamWithFailover(candidates, 0, resolved, tools, history, augmentedMessage, fullResponse)
                                     .doOnComplete(() -> log.debug("[AI] LLM streaming complete, raw response: {} chars", fullResponse.length()))
                                     .then(Mono.defer(() -> {
                                         // Post-process: enrich response with document links
@@ -196,9 +197,18 @@ public class AiChatServiceImpl implements AiChatService {
      * </ul>
      * The failed model is benched in {@link AiFallbackChain} on the way out, so the requests that
      * follow skip it instead of each paying the same failing call.
+     * <p>
+     * A refused API key is handled separately from those retryable failures. When the provider
+     * rejects the credentials of the model the user is actually on ({@code primary} — their BYOK
+     * choice or the server default), the error surfaces: rerouting would hide a broken key an
+     * operator has to fix. When it rejects a key that came from a fallback <em>pool</em>, the
+     * whole key is disabled and the next candidate is tried instead — a pool of keys exists
+     * precisely so one of them failing is survivable. It is logged at ERROR with the key's
+     * fingerprint either way, so a bad pool key is loud rather than silent.
      */
-    private Flux<String> streamWithFailover(List<ResolvedChat> candidates, int index, DocumentAiTools tools,
-                                            List<Message> history, String augmentedMessage, StringBuilder fullResponse) {
+    private Flux<String> streamWithFailover(List<ResolvedChat> candidates, int index, ResolvedChat primary,
+                                            DocumentAiTools tools, List<Message> history,
+                                            String augmentedMessage, StringBuilder fullResponse) {
         ResolvedChat candidate = candidates.get(index);
         tools.rebindChatModel(candidate.chatModel());
         ChatClient chatClient = assembler.assemble(candidate.chatModel(), tools);
@@ -218,27 +228,56 @@ public class AiChatServiceImpl implements AiChatService {
                     AiFailoverPolicy.Failure failure = AiFailoverPolicy.classify(error);
                     fallbackChain.trip(candidate, failure);
 
-                    boolean hasNextCandidate = index + 1 < candidates.size();
+                    // A pool key the provider refuses is retryable on the *next key*, though not
+                    // on another model of the same key — so it gets its own path rather than
+                    // Failure.shouldFailover().
+                    boolean pooledKeyRefused = failure == AiFailoverPolicy.Failure.CREDENTIALS_REJECTED
+                            && candidate != primary;
+                    if (pooledKeyRefused && fallbackChain.disableKey(candidate)) {
+                        log.error("[AI] {} rejected the fallback API key {} — dropping it from the pool "
+                                        + "for the rest of this process; fix or remove it in "
+                                        + "AI_FALLBACK_KEYS_{}",
+                                candidate.provider(), candidate.keyRef(),
+                                candidate.provider().toUpperCase(Locale.ROOT));
+                    }
+
+                    boolean mayRetry = failure.shouldFailover() || pooledKeyRefused;
+                    // Skip past any candidate whose key was disabled — including by the line
+                    // above — so a dead key costs one refused call, not one per model on it.
+                    int nextIndex = nextUsable(candidates, index);
+                    boolean hasNextCandidate = nextIndex >= 0;
                     boolean nothingStreamed = fullResponse.isEmpty();
                     boolean nothingMutated = tools.getModifiedFolders().isEmpty();
 
-                    if (!failure.shouldFailover() || !hasNextCandidate || !nothingStreamed || !nothingMutated) {
-                        if (failure.shouldFailover() && !hasNextCandidate) {
-                            log.error("[AI] {} on {} ({}) and no fallback model left",
-                                    failure, candidate.provider(), candidate.model());
-                        } else if (failure.shouldFailover()) {
-                            log.error("[AI] {} on {} ({}) but cannot retry safely (streamed={}, mutated={})",
-                                    failure, candidate.provider(), candidate.model(),
+                    if (!mayRetry || !hasNextCandidate || !nothingStreamed || !nothingMutated) {
+                        if (mayRetry && !hasNextCandidate) {
+                            log.error("[AI] {} on {} ({}, key {}) and no fallback model left",
+                                    failure, candidate.provider(), candidate.model(), candidate.keyRef());
+                        } else if (mayRetry) {
+                            log.error("[AI] {} on {} ({}, key {}) but cannot retry safely (streamed={}, mutated={})",
+                                    failure, candidate.provider(), candidate.model(), candidate.keyRef(),
                                     !nothingStreamed, !nothingMutated);
                         }
                         return Flux.error(error);
                     }
 
-                    ResolvedChat next = candidates.get(index + 1);
-                    log.warn("[AI] {} on {} ({}) — falling back to {} ({})", failure,
-                            candidate.provider(), candidate.model(), next.provider(), next.model());
-                    return streamWithFailover(candidates, index + 1, tools, history, augmentedMessage, fullResponse);
+                    ResolvedChat next = candidates.get(nextIndex);
+                    log.warn("[AI] {} on {} ({}, key {}) — falling back to {} ({}, key {})", failure,
+                            candidate.provider(), candidate.model(), candidate.keyRef(),
+                            next.provider(), next.model(), next.keyRef());
+                    return streamWithFailover(candidates, nextIndex, primary, tools, history,
+                            augmentedMessage, fullResponse);
                 });
+    }
+
+    /** Index of the next candidate still worth an attempt, or -1 when the chain is spent. */
+    private int nextUsable(List<ResolvedChat> candidates, int index) {
+        for (int i = index + 1; i < candidates.size(); i++) {
+            if (fallbackChain.isUsable(candidates.get(i))) {
+                return i;
+            }
+        }
+        return -1;
     }
 
     @Override

--- a/openfilz-api/src/test/java/org/openfilz/dms/service/ai/AiFailoverPolicyTest.java
+++ b/openfilz-api/src/test/java/org/openfilz/dms/service/ai/AiFailoverPolicyTest.java
@@ -35,6 +35,15 @@ class AiFailoverPolicyTest {
         AuthenticationException(String message) { super(message); }
     }
 
+    private static class NotFoundException extends RuntimeException {
+        NotFoundException(String message) { super(message); }
+    }
+
+    /** Stand-in for the Google GenAI SDK's 5xx exception. */
+    private static class ServerException extends RuntimeException {
+        ServerException(String message) { super(message); }
+    }
+
     /** Spring AI wraps every provider failure in this generic runtime exception. */
     private static RuntimeException springAiWrapped(Throwable cause) {
         return new RuntimeException("Failed to generate content", cause);
@@ -75,7 +84,7 @@ class AiFailoverPolicyTest {
         assertThat(AiFailoverPolicy.classify(new ClientException("403 . Quota exceeded for this project")))
                 .isEqualTo(Failure.QUOTA_EXHAUSTED);
         assertThat(AiFailoverPolicy.classify(new ClientException("403 . PERMISSION_DENIED: caller lacks permission")))
-                .isEqualTo(Failure.NOT_FAILOVER);
+                .isEqualTo(Failure.CREDENTIALS_REJECTED);
     }
 
     @Test
@@ -95,12 +104,26 @@ class AiFailoverPolicyTest {
     }
 
     @Test
-    @DisplayName("credential and request errors never fail over — masking them hides the real fix")
-    void refusesToMaskConfigurationErrors() {
+    @DisplayName("a refused key is named as such — never as a retryable failure")
+    void classifiesRejectedCredentials() {
         assertThat(AiFailoverPolicy.classify(new ClientException("401 . API key not valid. Please pass a valid API key.")))
-                .isEqualTo(Failure.NOT_FAILOVER);
+                .isEqualTo(Failure.CREDENTIALS_REJECTED);
         assertThat(AiFailoverPolicy.classify(springAiWrapped(new AuthenticationException("invalid x-api-key"))))
-                .isEqualTo(Failure.NOT_FAILOVER);
+                .isEqualTo(Failure.CREDENTIALS_REJECTED);
+        // The production failure this whole path exists for: Google answers a key it will not
+        // accept on generativelanguage.googleapis.com with 401 ACCESS_TOKEN_TYPE_UNSUPPORTED.
+        assertThat(AiFailoverPolicy.classify(springAiWrapped(new ClientException(
+                "401 . Request had invalid authentication credentials. Expected OAuth 2 access "
+                        + "token, login cookie or other valid authentication credential."))))
+                .isEqualTo(Failure.CREDENTIALS_REJECTED);
+        // Retrying the same key on another model is pointless — only another key can help, and
+        // that decision belongs to the caller, which knows whether this key came from a pool.
+        assertThat(Failure.CREDENTIALS_REJECTED.shouldFailover()).isFalse();
+    }
+
+    @Test
+    @DisplayName("request errors and bugs never fail over — masking them hides the real fix")
+    void refusesToMaskConfigurationErrors() {
         assertThat(AiFailoverPolicy.classify(new ClientException("400 . Invalid JSON payload received.")))
                 .isEqualTo(Failure.NOT_FAILOVER);
         assertThat(AiFailoverPolicy.classify(new NullPointerException("boom")))
@@ -108,6 +131,40 @@ class AiFailoverPolicyTest {
         assertThat(AiFailoverPolicy.classify(new RuntimeException()))
                 .isEqualTo(Failure.NOT_FAILOVER);
         assertThat(Failure.NOT_FAILOVER.shouldFailover()).isFalse();
+    }
+
+    @Test
+    @DisplayName("'API key' wording in a wrapper does not mask a quota or retired model below it")
+    void credentialWordingLosesToADefiniteVerdictDeeper() {
+        // Providers mention the API key in errors that have nothing to do with the key being
+        // wrong. Short-circuiting on that wording would disable a perfectly good pool key.
+        assertThat(AiFailoverPolicy.classify(new RuntimeException(
+                "the API key could not complete the request",
+                new ClientException("429 . You exceeded your current quota"))))
+                .isEqualTo(Failure.QUOTA_EXHAUSTED);
+        assertThat(AiFailoverPolicy.classify(new RuntimeException(
+                "check that your api key has access",
+                new ClientException("404 . models/gemini-2.5-flash is no longer available"))))
+                .isEqualTo(Failure.MODEL_UNAVAILABLE);
+        assertThat(AiFailoverPolicy.classify(new RuntimeException(
+                "api key rejected",
+                new ClientException("503 . The model is overloaded"))))
+                .isEqualTo(Failure.PROVIDER_OVERLOADED);
+    }
+
+    @Test
+    @DisplayName("a typed provider exception classifies even when its message says nothing")
+    void classifiesFromExceptionTypeAlone() {
+        // These used to pass only because the messages happened to carry matching keywords; a
+        // provider that throws a typed exception with an unhelpful message has to work too.
+        assertThat(AiFailoverPolicy.classify(springAiWrapped(new RateLimitException("boom"))))
+                .isEqualTo(Failure.QUOTA_EXHAUSTED);
+        assertThat(AiFailoverPolicy.classify(springAiWrapped(new AuthenticationException("boom"))))
+                .isEqualTo(Failure.CREDENTIALS_REJECTED);
+        assertThat(AiFailoverPolicy.classify(springAiWrapped(new NotFoundException("boom"))))
+                .isEqualTo(Failure.MODEL_UNAVAILABLE);
+        assertThat(AiFailoverPolicy.classify(springAiWrapped(new ServerException("boom"))))
+                .isEqualTo(Failure.PROVIDER_OVERLOADED);
     }
 
     @Test

--- a/openfilz-api/src/test/java/org/openfilz/dms/service/ai/AiFallbackChainTest.java
+++ b/openfilz-api/src/test/java/org/openfilz/dms/service/ai/AiFallbackChainTest.java
@@ -261,12 +261,22 @@ class AiFallbackChainTest {
     /** One chat request, mirroring {@code AiChatServiceImpl#streamWithFailover}. */
     private String ask(ResolvedChat primary, Instant now) {
         for (ResolvedChat candidate : chain.candidates(primary, now)) {
+            if (!chain.isUsable(candidate)) {
+                continue;   // its key was disabled earlier in this same walk
+            }
             try {
                 return providers.call(candidate);
             } catch (RuntimeException e) {
                 Failure failure = AiFailoverPolicy.classify(e);
                 chain.trip(candidate, failure, now);
-                if (!failure.shouldFailover()) {
+                // Mirrors AiChatServiceImpl#streamWithFailover: a key the provider refuses is
+                // dropped and the walk continues when it came from a pool; on the primary it
+                // surfaces, so a single-key deployment sees its own broken key.
+                boolean pooledKeyRefused = failure == Failure.CREDENTIALS_REJECTED && candidate != primary;
+                if (pooledKeyRefused) {
+                    chain.disableKey(candidate);
+                }
+                if (!failure.shouldFailover() && !pooledKeyRefused) {
                     return "ERROR:" + e.getCause().getMessage();
                 }
             }
@@ -350,16 +360,45 @@ class AiFallbackChainTest {
     }
 
     @Test
-    @DisplayName("a revoked key surfaces as an error instead of quietly rotating to the next one")
-    void revokedKeyDoesNotFailOver() {
-        chain("google:m1");
+    @DisplayName("a refused pool key is dropped for good and the next key of that provider answers")
+    void refusedPoolKeyIsDroppedAndTheNextKeyAnswers() {
+        chain("google:m1", "google:m2");
         keys(AiProvider.GOOGLE, GOOGLE_A, GOOGLE_B);
         ResolvedChat primary = benchedPrimary();
         providers.revokedKeys.add(AiKeyRef.of(GOOGLE_A));
 
+        assertThat(ask(primary, T0.plusSeconds(10))).isEqualTo("GOOGLE|" + AiKeyRef.of(GOOGLE_B) + "|m1");
+        // Gone from the pool, not merely benched: a key the provider refuses will not recover on
+        // its own, so no cooldown would ever be the right length.
+        assertThat(view(chain.candidates(primary, T0.plusSeconds(11))))
+                .doesNotContain("GOOGLE/m1/google-key-A", "GOOGLE/m2/google-key-A");
+        // And exactly one refused call was paid for it — not one per model on that key.
+        assertThat(ask(primary, T0.plusSeconds(12))).endsWith("|m1");
+        assertThat(providers.callsMatching(AiKeyRef.of(GOOGLE_A))).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("a refused key on the model in use surfaces — a broken key must never be masked")
+    void refusedPrimaryKeyDoesNotFailOver() {
+        chain("google:m1");
+        keys(AiProvider.GOOGLE, GOOGLE_A, GOOGLE_B);
+        // The model the user is actually on, carrying the broken key: the single-key deployment.
+        ResolvedChat primary = new ResolvedChat(mock(ChatModel.class), "google-genai", "m0", AiKeyRef.of(GOOGLE_A));
+        providers.revokedKeys.add(AiKeyRef.of(GOOGLE_A));
+
         assertThat(ask(primary, T0.plusSeconds(10))).startsWith("ERROR:401");
-        // Not benched either — the operator must keep seeing the real error until they fix the key.
         assertThat(view(chain.candidates(primary, T0.plusSeconds(11)))).contains("GOOGLE/m1/google-key-A");
+    }
+
+    @Test
+    @DisplayName("a key with no fingerprint cannot be disabled — it would take unrelated keys with it")
+    void unfingerprintedKeyIsNeverDisabled() {
+        chain("google:m1");
+        keys(AiProvider.GOOGLE, GOOGLE_A);
+
+        ResolvedChat anonymous = new ResolvedChat(mock(ChatModel.class), "GOOGLE", "m1", AiKeyRef.UNKNOWN);
+        assertThat(chain.disableKey(anonymous)).isFalse();
+        assertThat(chain.isUsable(anonymous)).isTrue();
     }
 
     // ------------------------------------------------------------------ configuration handling


### PR DESCRIPTION
## The failure

A deployment with three Google keys in `AI_FALLBACK_KEYS_GOOGLE` lost chat entirely the first time the primary model hit its quota:

```
[AI-FALLBACK] QUOTA_EXHAUSTED on google:90685e26:gemini-3.6-flash — benching it for PT5M
[AI] QUOTA_EXHAUSTED on google-genai (gemini-3.6-flash) — falling back to GOOGLE (gemini-3.7-flash)
Caused by: com.google.genai.errors.ClientException: 401 . Request had invalid authentication
credentials. Expected OAuth 2 access token... reason: ACCESS_TOKEN_TYPE_UNSUPPORTED
[AI] Error during AI chat streaming
```

Failover fired correctly. The next candidate was refused, and the request died there — with **eleven untried candidates behind it**, including every model on the other two keys.

## Two defects

**1. A refused key ended the walk.**

Credential failures deliberately did not fail over, so that a broken key surfaces rather than being masked. That is right for the model the user is actually on — the server default, or a BYOK user's own choice. It is wrong for a key that came from a *pool*, which exists precisely so one key failing is survivable.

`AiFailoverPolicy` now names that case (`CREDENTIALS_REJECTED`) instead of folding it into `NOT_FAILOVER`, and `AiChatServiceImpl` decides per candidate:

| refused key belongs to | behaviour |
|---|---|
| the model in use (primary / BYOK) | error propagates — unchanged |
| a fallback pool | key dropped from rotation, next key takes over |

A dropped key is logged at ERROR with the key's **fingerprint**, never the key:

```
[AI] GOOGLE rejected the fallback API key c59be430 — dropping it from the pool for the rest of
this process; fix or remove it in AI_FALLBACK_KEYS_GOOGLE
```

`AiFallbackChain.isUsable` lets the walk skip the remaining candidates on a key it just disabled, so a dead key costs **one** refused call rather than one per model on it (4 models × 3 keys made that difference visible).

**2. `containsAny` lowercased the haystack but not the needles.**

Every `*_TYPES` rule — `"RateLimit"`, `"Authentication"`, `"NotFound"`, `"ServerException"`, … — was compared against a lower-cased class name and could never match. Typed-exception classification was dead code throughout; the cases that appeared to work did so through message keywords instead. Found by a test harness, not by reading.

## A related ordering choice

`CREDENTIALS_REJECTED` is the *weakest* verdict when walking a cause chain. Providers mention "API key" in errors that have nothing to do with the key being wrong — a retired model or a spent quota often does — and letting that wording short-circuit would now disable a perfectly good pool key. A definite 429/404/5xx deeper in the chain still wins.

## Verification

Both classes were compiled and exercised against standalone harnesses (the repo targets Java 25; only 21 is available here, so the real Maven build runs in CI):

- `AiFailoverPolicy` — **32/32**, including the verbatim production 401, the four typed-exception cases with deliberately unhelpful messages, and the wrapper-wording guard.
- `AiFallbackChain` — **45/45**, including a refused pool key being dropped and the next key answering, a refused *primary* key still propagating, one-call-per-dead-key, an unfingerprinted key never disabling anything, and the existing secret-hygiene assertion that no raw key reaches a log line.

Both sets are mirrored as JUnit tests in this PR.

Also confirmed empirically against `generativelanguage.googleapis.com` that `401 ACCESS_TOKEN_TYPE_UNSUPPORTED` is returned only when an `Authorization` header is present — a missing, empty, malformed or unknown API key yields 400/403 instead. So the refused key is genuinely rejected by Google as a credential; this PR makes that survivable and diagnosable rather than fatal.

## Docs

`docs/admin-guide.md` and `deploy/docker-compose/dokploy/.env.example` updated — the previous "a bad API key never triggers failover" is now accurate about which key it means, and documents what a refused pool key looks like in the logs.

---
_Generated by [Claude Code](https://claude.ai/code/session_013KV23y5acwYwbhFLEa4DhK)_