### PR TITLE
fix(ai): folder="all" searched only the root level

### DIFF
--- a/openfilz-api/src/main/java/org/openfilz/dms/service/ai/AiDocumentQueryService.java
+++ b/openfilz-api/src/main/java/org/openfilz/dms/service/ai/AiDocumentQueryService.java
@@ -64,14 +64,13 @@ public class AiDocumentQueryService {
      * restrict results to the user's own and shared documents.
      */
     public List<FullDocumentInfo> query(ListFolderRequest request, String userEmail) {
-        log.debug("[AI-QUERY] query: folder={}, nameLike={}, type={}, sort={}:{}, page={}/{}",
-                request.id(), request.nameLike(), request.type(),
+        log.debug("[AI-QUERY] query: scope={}, nameLike={}, type={}, sort={}:{}, page={}/{}",
+                scope(request), request.nameLike(), request.type(),
                 request.pageInfo().sortBy(), request.pageInfo().sortOrder(),
                 request.pageInfo().pageNumber(), request.pageInfo().pageSize());
 
         StringBuilder query = buildSelect(userEmail);
-        criteria.checkFilter(request);
-        criteria.applyFilter(PREFIX, query, request);
+        applyFilter(query, request);
         applySort(query, request);
         appendOffsetLimit(query, request);
 
@@ -90,12 +89,11 @@ public class AiDocumentQueryService {
      * Count documents matching the filter (same filtering as query, no sort/pagination).
      */
     public long count(ListFolderRequest request, String userEmail) {
-        log.debug("[AI-QUERY] count: folder={}, nameLike={}, type={}", request.id(), request.nameLike(), request.type());
+        log.debug("[AI-QUERY] count: scope={}, nameLike={}, type={}", scope(request), request.nameLike(), request.type());
 
         StringBuilder query = new StringBuilder("select count(*)");
         appendFromClause(query, userEmail);
-        criteria.checkFilter(request);
-        criteria.applyFilter(PREFIX, query, request);
+        applyFilter(query, request);
 
         log.debug("[AI-QUERY] SQL: {}", query);
 
@@ -106,6 +104,45 @@ public class AiDocumentQueryService {
         Long result = sql.map(row -> row.get(0, Long.class)).one().block();
         log.debug("[AI-QUERY] Count: {}", result);
         return result != null ? result : 0;
+    }
+
+    /**
+     * Apply the request's filters, honouring a whole-tree search.
+     * <p>
+     * {@link ListFolderCriteria} is written for a folder <em>listing</em>, where a null id means
+     * "the root level" and {@code recursive} only widens an id that was given. An AI search for
+     * {@code folder="all"} means something else entirely — every document at every depth — and
+     * arrives here as exactly that combination: no id, recursive true. Left to the shared
+     * criteria it silently became {@code parent_id IS NULL}, so a global search only ever saw
+     * root-level documents and the model had to walk the tree folder by folder, one LLM call per
+     * folder. Here that combination emits no parent predicate at all.
+     * <p>
+     * Handled in this service rather than in the shared criteria on purpose: the GraphQL contract
+     * documents {@code recursive} as "when true and id is set", and other callers rely on a null
+     * id meaning the root level.
+     */
+    private void applyFilter(StringBuilder query, ListFolderRequest request) {
+        criteria.checkFilter(request);
+        if (searchesWholeTree(request)) {
+            criteria.appendAllFilterExceptParentId(PREFIX, query, request, false);
+        } else {
+            criteria.applyFilter(PREFIX, query, request);
+        }
+    }
+
+    /**
+     * The folder scope, for logs. {@code folder=null} was ambiguous between "the root level" and
+     * "everywhere" — the two the parent-id bug conflated — so it names them apart.
+     */
+    private static String scope(ListFolderRequest request) {
+        if (searchesWholeTree(request)) return "all folders";
+        if (request.id() == null) return "root level only";
+        return (Boolean.TRUE.equals(request.recursive()) ? "folder+subfolders " : "folder ") + request.id();
+    }
+
+    /** Whether this request asks for every document at every depth, rather than one folder's contents. */
+    private static boolean searchesWholeTree(ListFolderRequest request) {
+        return request.id() == null && Boolean.TRUE.equals(request.recursive());
     }
 
     /**

--- a/openfilz-api/src/test/java/org/openfilz/dms/service/ai/AiDocumentQueryScopeTest.java
+++ b/openfilz-api/src/test/java/org/openfilz/dms/service/ai/AiDocumentQueryScopeTest.java
@@ -1,0 +1,123 @@
+package org.openfilz.dms.service.ai;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.openfilz.dms.dto.request.ListFolderRequest;
+import org.openfilz.dms.dto.request.PageCriteria;
+import org.openfilz.dms.enums.DocumentType;
+import org.openfilz.dms.enums.SortOrder;
+import org.openfilz.dms.repository.graphql.ListFolderCriteria;
+import org.openfilz.dms.utils.SqlUtils;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * The SQL scope of an AI document query.
+ * <p>
+ * {@link ListFolderCriteria} is written for a folder <em>listing</em>, where a null id means "the
+ * root level". An AI search for {@code folder="all"} means the opposite — every document at every
+ * depth — and reaches the criteria as "no id, recursive true", which it read as root-only. In
+ * production that made a global search silently return root-level documents only, and the model
+ * walked the tree folder by folder instead, one LLM call per folder, until the provider's
+ * per-minute quota ran out.
+ * <p>
+ * These assert on the emitted SQL because the scope <em>is</em> the SQL: the parent-id predicate
+ * (or its absence) is the whole behaviour under test.
+ */
+class AiDocumentQueryScopeTest {
+
+    private static final String PREFIX = "d.";
+    private static final UUID FOLDER = UUID.fromString("86849cc3-9885-4cbf-8a43-c0ef5544f6c2");
+
+    // The ObjectMapper is only reached by metadata binding, which no scope test exercises.
+    private final ListFolderCriteria criteria = new ListFolderCriteria(new SqlUtils(mock(ObjectMapper.class)));
+
+    /** The request shape {@code DocumentAiTools#queryDocuments} builds, with the scope under test. */
+    private static ListFolderRequest request(UUID folderId, Boolean recursive, String nameLike) {
+        return new ListFolderRequest(folderId, DocumentType.FILE, null, null, nameLike, null, null,
+                null, null, null, null, null, null, null, true,
+                new PageCriteria("createdAt", SortOrder.DESC, 1, 50), recursive);
+    }
+
+    /** Mirrors {@code AiDocumentQueryService#applyFilter}. */
+    private String sql(ListFolderRequest request) {
+        StringBuilder query = new StringBuilder("select * from Documents d");
+        criteria.checkFilter(request);
+        if (request.id() == null && Boolean.TRUE.equals(request.recursive())) {
+            criteria.appendAllFilterExceptParentId(PREFIX, query, request, false);
+        } else {
+            criteria.applyFilter(PREFIX, query, request);
+        }
+        return query.toString();
+    }
+
+    /** What the shared criteria alone produces — the pre-fix behaviour. */
+    private String sqlFromSharedCriteriaAlone(ListFolderRequest request) {
+        StringBuilder query = new StringBuilder("select * from Documents d");
+        criteria.checkFilter(request);
+        criteria.applyFilter(PREFIX, query, request);
+        return query.toString();
+    }
+
+    @Test
+    @DisplayName("folder='all' searches every folder at every depth, not just the root")
+    void searchesTheWholeTree() {
+        ListFolderRequest all = request(null, true, "pdf");
+
+        String sql = sql(all);
+
+        assertThat(sql).doesNotContain("parent_id");
+        assertThat(sql).contains("d.type = :type", "UPPER(d.name) LIKE :name", "d.active = :active");
+        // The remaining filters must still open the WHERE clause themselves.
+        assertThat(sql).contains(" WHERE d.type").doesNotContain("WHERE AND");
+        assertThat(sql.split(" WHERE ", -1)).hasSize(2);
+
+        // The production symptom this fixes: the shared criteria alone scoped it to the root.
+        assertThat(sqlFromSharedCriteriaAlone(all)).contains("d.parent_id is null");
+    }
+
+    @Test
+    @DisplayName("folder='root' still means the root level only")
+    void rootStaysRootOnly() {
+        ListFolderRequest root = request(null, false, null);
+
+        assertThat(sql(root)).contains("d.parent_id is null");
+        assertThat(sql(root)).isEqualTo(sqlFromSharedCriteriaAlone(root));
+    }
+
+    @Test
+    @DisplayName("a named folder still lists that folder's own contents")
+    void namedFolderIsUnchanged() {
+        ListFolderRequest named = request(FOLDER, false, null);
+
+        assertThat(sql(named)).contains("d.parent_id = :parent_id");
+        assertThat(sql(named)).isEqualTo(sqlFromSharedCriteriaAlone(named));
+    }
+
+    @Test
+    @DisplayName("a folder searched recursively keeps the GraphQL contract's descendants CTE")
+    void recursiveWithinAFolderIsUnchanged() {
+        ListFolderRequest deep = request(FOLDER, true, null);
+
+        assertThat(sql(deep)).contains("WITH RECURSIVE descendants");
+        assertThat(sql(deep)).isEqualTo(sqlFromSharedCriteriaAlone(deep));
+    }
+
+    @Test
+    @DisplayName("counting across all folders is scoped the same way as listing them")
+    void countUsesTheSameScope() {
+        // countOnly requests carry no PageCriteria.
+        ListFolderRequest countAll = new ListFolderRequest(null, DocumentType.FILE, null, null, null, null, null,
+                null, null, null, null, null, null, null, true, null, true);
+
+        StringBuilder query = new StringBuilder("select count(*) from Documents d");
+        criteria.appendAllFilterExceptParentId(PREFIX, query, countAll, false);
+
+        assertThat(query.toString()).doesNotContain("parent_id");
+        assertThat(query.toString()).contains("d.type = :type", "d.active = :active");
+    }
+}


### PR DESCRIPTION
## The bug

`DocumentAiTools#queryDocuments` advertises `folder="all"` as *"search across all folders"*, and the system prompt tells the model to use it for every global search — `"latest file"`, `"count files"`, `"search for CV"`. It returned **root-level documents only**.

`DocumentAiTools` already translated `"all"` correctly, into a request with no folder id and `recursive=true`. `ListFolderCriteria` is written for a folder *listing*, though: a null id means "the root level", and `recursive` only widens an id that was actually given. That combination fell through to `parent_id IS NULL`.

## Why it mattered more than it looks

Nothing failed — it just answered from the root. Seen in production, asking *"find all PDFs I recently added, not only at the root level, in all subfolders as well"*:

```
[AI-TOOL] queryDocuments called: folder='all', nameLike='pdf', type='FILE'
[AI-QUERY] SQL: ... WHERE d.parent_id is null AND d.type = $1 AND UPPER(d.name) LIKE $2 ...
[AI-QUERY] Returned 0 results
```

The model compensated by walking the tree itself — list the folders, then query each one, one LLM call per folder. On a Google free tier metered at **5 requests per minute per model**, that single question spent the quota and tripped the failover chain before it could answer:

```
Quota exceeded ... quotaId: GenerateRequestsPerMinutePerProjectPerModel-FreeTier, quotaValue: 5
[AI] QUOTA_EXHAUSTED on google-genai (gemini-3.6-flash, key 90685e26) — falling back to GOOGLE (gemini-3.7-flash, key 90685e26)
```

The failover did its job. The reason it was needed at all was this.

## The fix

`AiDocumentQueryService` emits no parent predicate for that combination, in `query()` and `count()` alike.

Deliberately **not** fixed in the shared `ListFolderCriteria`: `document.graphqls` documents `recursive` as *"When true and id is set, search recursively in all subfolders of the given folder"*, and other callers rely on a null id meaning the root level. Scoping the change to the AI service leaves the GraphQL contract exactly as it was.

The `[AI-QUERY]` log also printed `folder=null` for both "the root level" and "everywhere" — the two scopes the bug conflated, which is what made it hard to see. It now names the scope (`all folders` / `root level only` / `folder <id>`).

## Verification

Compiled the real `ListFolderCriteria` + `SqlUtils` against minimal stubs and asserted the emitted SQL (the repo targets Java 25; only 21 is available in this environment, so the Maven build runs in CI) — **12/12**:

| scope | SQL |
|---|---|
| `folder="all"` | `WHERE d.type = :type AND UPPER(d.name) LIKE :name AND d.active = :active` — no `parent_id`, one `WHERE`, no dangling `AND` |
| `folder="root"` | `WHERE d.parent_id is null AND ...` — byte-identical to before |
| named folder | `WHERE d.parent_id = :parent_id AND ...` — byte-identical to before |
| id + `recursive` | `WITH RECURSIVE descendants` CTE — byte-identical to before |
| `count()` over all | no `parent_id` predicate |

Mirrored as `AiDocumentQueryScopeTest`. `bindCriteria` already guards on `id != null`, so the removed predicate leaves no orphan bind parameter.

Three documented behaviours are corrected by the same change: `"latest file"` now finds the latest file anywhere rather than the latest at the root, `"count files"` counts the whole library, and a name search reaches subfolders.

---
_Generated by [Claude Code](https://claude.ai/code/session_013KV23y5acwYwbhFLEa4DhK)_