### PR TITLE
feat(ai): ask the provider which chat models a BYOK key can use

### DIFF
--- a/deploy/docker-compose/.env.example
+++ b/deploy/docker-compose/.env.example
@@ -197,7 +197,10 @@ OLLAMA_PORT=11434
 # Create a key at https://aistudio.google.com (free tier available)
 # GOOGLE_API_KEY=AIza-your-key-here
 # GOOGLE_CHAT_ENABLED=true
-# GOOGLE_CHAT_MODEL=gemini-2.5-flash
+# Pin the model explicitly — providers retire ids, and a retired one fails every chat with a
+# 404 ("no longer available to new users") until this is updated. gemini-flash-latest always
+# tracks the current flash model if you would rather not pin.
+# GOOGLE_CHAT_MODEL=gemini-3.6-flash
 
 # Per-user AI settings (BYOK): let each user override the chat LLM with their own
 # provider + API key from the personal settings page. Stored keys are encrypted with

--- a/deploy/helm/openfilz-api/values.yaml
+++ b/deploy/helm/openfilz-api/values.yaml
@@ -170,11 +170,14 @@ ai:
       enabled: false
       model: "claude-opus-5"
   # -- Google Gemini via the Gemini Developer API (chat only — embeddings stay on Ollama/OpenAI)
+  # Google retires model ids, and a retired one fails every chat with a 404 ("no longer
+  # available to new users"): set model to "gemini-flash-latest" to track the current flash
+  # model instead of pinning one.
   google:
     apiKey: ""
     chat:
       enabled: false
-      model: "gemini-2.5-flash"
+      model: "gemini-3.6-flash"
   # -- Per-user AI settings (BYOK): users override the chat LLM with their own provider + API key.
   # encryptionKey protects the stored keys (base64, 32 bytes): openssl rand -base64 32
   userSettings:

--- a/openfilz-api/src/main/java/org/openfilz/dms/controller/rest/AiSettingsController.java
+++ b/openfilz-api/src/main/java/org/openfilz/dms/controller/rest/AiSettingsController.java
@@ -7,8 +7,10 @@ import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.openfilz.dms.config.AiProperties;
 import org.openfilz.dms.config.RestApiVersion;
+import org.openfilz.dms.dto.request.ListAiModelsRequest;
 import org.openfilz.dms.dto.request.SaveAiSettingsRequest;
 import org.openfilz.dms.dto.response.AiConnectionTestResult;
+import org.openfilz.dms.dto.response.AiModelsResponse;
 import org.openfilz.dms.dto.response.AiSettingsResponse;
 import org.openfilz.dms.service.AiSettingsService;
 import org.openfilz.dms.utils.UserInfoService;
@@ -82,5 +84,18 @@ public class AiSettingsController implements UserInfoService {
         requireAiActive();
         return getConnectedUserEmail()
                 .flatMap(email -> aiSettingsService.testConnection(email, request));
+    }
+
+    @PostMapping(value = "/models", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(summary = "List the provider's chat models",
+            description = "Ask the provider which chat models this key can use, so the picker "
+                    + "reflects what exists today rather than a list baked into a release. Falls "
+                    + "back to a built-in list (source=FALLBACK) when the provider cannot be "
+                    + "reached. POST rather than GET because the key travels in the body, never "
+                    + "in a query string; omit apiKey to use the stored key.")
+    public Mono<AiModelsResponse> listModels(@Valid @RequestBody ListAiModelsRequest request) {
+        requireAiActive();
+        return getConnectedUserEmail()
+                .flatMap(email -> aiSettingsService.listModels(email, request));
     }
 }

--- a/openfilz-api/src/main/java/org/openfilz/dms/dto/request/ListAiModelsRequest.java
+++ b/openfilz-api/src/main/java/org/openfilz/dms/dto/request/ListAiModelsRequest.java
@@ -1,0 +1,18 @@
+package org.openfilz.dms.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import org.openfilz.dms.enums.AiProvider;
+
+/**
+ * Ask a provider which chat models the given key can actually use (BYOK model picker).
+ * <p>
+ * The key travels in the body rather than a query string on purpose: query strings end up in
+ * access logs and browser history. {@code apiKey} may be omitted to use the stored key, which is
+ * what the settings page does once a key has been saved.
+ */
+public record ListAiModelsRequest(
+        @NotNull @Schema(description = "Chat LLM provider") AiProvider provider,
+        @Schema(description = "Base URL — required for OPENAI_COMPATIBLE, ignored otherwise") String baseUrl,
+        @Schema(description = "API key (write-only). Omit to use the stored key.") String apiKey) {
+}

--- a/openfilz-api/src/main/java/org/openfilz/dms/dto/response/AiModelsResponse.java
+++ b/openfilz-api/src/main/java/org/openfilz/dms/dto/response/AiModelsResponse.java
@@ -1,0 +1,30 @@
+package org.openfilz.dms.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.openfilz.dms.enums.AiProvider;
+
+import java.util.List;
+
+/**
+ * The chat models a provider currently offers for a given key.
+ *
+ * @param source LIVE when the list came from the provider, FALLBACK when the call failed and the
+ *               built-in list is being offered instead — the picker stays usable either way, and
+ *               the caller can say which it is showing.
+ */
+public record AiModelsResponse(
+        @Schema(description = "Provider the list belongs to") AiProvider provider,
+        @Schema(description = "Model ids, best default first") List<String> models,
+        @Schema(description = "LIVE or FALLBACK") Source source,
+        @Schema(description = "Why the provider list is unavailable, when source is FALLBACK") String message) {
+
+    public enum Source { LIVE, FALLBACK }
+
+    public static AiModelsResponse live(AiProvider provider, List<String> models) {
+        return new AiModelsResponse(provider, models, Source.LIVE, null);
+    }
+
+    public static AiModelsResponse fallback(AiProvider provider, List<String> models, String message) {
+        return new AiModelsResponse(provider, models, Source.FALLBACK, message);
+    }
+}

--- a/openfilz-api/src/main/java/org/openfilz/dms/service/AiSettingsService.java
+++ b/openfilz-api/src/main/java/org/openfilz/dms/service/AiSettingsService.java
@@ -1,7 +1,9 @@
 package org.openfilz.dms.service;
 
+import org.openfilz.dms.dto.request.ListAiModelsRequest;
 import org.openfilz.dms.dto.request.SaveAiSettingsRequest;
 import org.openfilz.dms.dto.response.AiConnectionTestResult;
+import org.openfilz.dms.dto.response.AiModelsResponse;
 import org.openfilz.dms.dto.response.AiSettingsResponse;
 import reactor.core.publisher.Mono;
 
@@ -22,4 +24,12 @@ public interface AiSettingsService {
      * (falling back to the stored API key when the request carries none).
      */
     Mono<AiConnectionTestResult> testConnection(String userEmail, SaveAiSettingsRequest request);
+
+    /**
+     * The chat models the provider currently offers for this key, so the picker reflects what
+     * exists today rather than what existed at release time. Falls back to a built-in list — never
+     * an error — when the provider cannot be asked: a model picker that cannot list is still
+     * usable, since the field takes free text.
+     */
+    Mono<AiModelsResponse> listModels(String userEmail, ListAiModelsRequest request);
 }

--- a/openfilz-api/src/main/java/org/openfilz/dms/service/ai/AiModelCatalog.java
+++ b/openfilz-api/src/main/java/org/openfilz/dms/service/ai/AiModelCatalog.java
@@ -1,0 +1,105 @@
+package org.openfilz.dms.service.ai;
+
+import org.openfilz.dms.enums.AiProvider;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * What to show in the BYOK model picker: which of a provider's models are chat models, what order
+ * to offer them in, and what to fall back to when the provider cannot be reached.
+ * <p>
+ * The fallback lists exist because a hardcoded list is exactly what went wrong before — OpenFilz
+ * shipped {@code gemini-2.5-flash} as the Google default until Google retired it and every chat
+ * started answering {@code 404 . This model ... is no longer available to new users}. A live list
+ * from {@link AiModelDirectory} is therefore the normal path; these are the safety net for a
+ * provider outage or a key that cannot list models, not the source of truth.
+ */
+public final class AiModelCatalog {
+
+    private AiModelCatalog() {
+    }
+
+    /**
+     * Known-good chat models per provider, best default first.
+     * <p>
+     * Also the ranking applied to a live list: whatever the provider returns, these float to the
+     * top in this order, because the caller pre-fills the model field with the first entry and
+     * that entry has to be a sensible default rather than whichever id the provider happened to
+     * return first.
+     */
+    private static final List<String> GOOGLE_PREFERRED = List.of(
+            "gemini-3.6-flash", "gemini-3.7-flash", "gemini-3.5-flash",
+            "gemini-3.5-flash-lite", "gemini-3.1-flash-lite",
+            "gemini-flash-latest", "gemini-flash-lite-latest", "gemini-pro-latest");
+
+    private static final List<String> ANTHROPIC_PREFERRED = List.of(
+            "claude-opus-5", "claude-sonnet-5", "claude-haiku-4-5");
+
+    private static final List<String> OPENAI_PREFERRED = List.of(
+            "gpt-4o", "gpt-4o-mini");
+
+    /**
+     * Substrings that mark a model as something other than a chat model.
+     * <p>
+     * Provider "list models" endpoints return the whole catalogue — text-to-speech, image and
+     * video generation, embeddings, transcription, robotics. Google's response carries
+     * {@code supportedGenerationMethods}, which is authoritative and checked first; several
+     * non-chat models nonetheless advertise {@code generateContent}, and OpenAI-shaped endpoints
+     * give no capability information at all, so the id is the only remaining signal.
+     * <p>
+     * Deliberately conservative: it is better to leave an odd model in the list — the field stays
+     * free text, so nothing is lost — than to hide one the user actually wants.
+     */
+    private static final List<String> NON_CHAT_MARKERS = List.of(
+            "embed", "-tts", "tts-", "text-to-speech", "whisper", "transcribe", "audio",
+            "realtime", "dall-e", "imagen", "-image", "image-", "veo-", "lyria",
+            "nano-banana", "robotics", "computer-use", "moderation", "rerank", "guard");
+
+    /** The built-in list for a provider, used when the provider cannot be asked. */
+    public static List<String> fallback(AiProvider provider) {
+        return switch (provider) {
+            case GOOGLE -> GOOGLE_PREFERRED;
+            case ANTHROPIC -> ANTHROPIC_PREFERRED;
+            case OPENAI -> OPENAI_PREFERRED;
+            case OPENAI_COMPATIBLE -> List.of();
+        };
+    }
+
+    /**
+     * Whether an id looks like a chat model. {@code supportsGeneration} carries the provider's own
+     * verdict where it has one ({@code null} when the provider says nothing).
+     */
+    public static boolean isChatModel(String modelId, Boolean supportsGeneration) {
+        if (modelId == null || modelId.isBlank()) return false;
+        if (Boolean.FALSE.equals(supportsGeneration)) return false;
+        String id = modelId.toLowerCase(Locale.ROOT);
+        for (String marker : NON_CHAT_MARKERS) {
+            if (id.contains(marker)) return false;
+        }
+        return true;
+    }
+
+    /**
+     * Order a provider's live list: the known-good models this provider actually returned first,
+     * in preference order, then everything else in the order the provider gave.
+     * <p>
+     * Self-healing by construction — when a preferred id disappears from the provider it simply
+     * stops matching, and the next one that does exist leads the list. That is the property the
+     * hardcoded list lacked.
+     */
+    public static List<String> ordered(AiProvider provider, List<String> providerModels) {
+        Set<String> available = new LinkedHashSet<>(providerModels);
+        List<String> out = new ArrayList<>();
+        for (String preferred : fallback(provider)) {
+            if (available.remove(preferred)) {
+                out.add(preferred);
+            }
+        }
+        out.addAll(available);
+        return List.copyOf(out);
+    }
+}

--- a/openfilz-api/src/main/java/org/openfilz/dms/service/ai/AiModelDirectory.java
+++ b/openfilz-api/src/main/java/org/openfilz/dms/service/ai/AiModelDirectory.java
@@ -1,0 +1,171 @@
+package org.openfilz.dms.service.ai;
+
+import lombok.extern.slf4j.Slf4j;
+import org.openfilz.dms.enums.AiProvider;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Asks a provider which models a given API key can use, so the BYOK picker offers what actually
+ * exists today instead of a list baked into a release.
+ * <p>
+ * Talks to the providers over plain HTTP rather than their SDKs: the "list models" endpoints are
+ * three trivial GETs, and keeping provider SDK types out of this path avoids the reflection that
+ * GraalVM native images object to. It also means an unknown OpenAI-compatible gateway works with
+ * no extra code, as long as it implements {@code /v1/models}.
+ * <p>
+ * Results are cached briefly per (provider, key): the settings page asks on every provider change
+ * and every key edit, and a listing is not worth a round trip each time. The cache is keyed by the
+ * key's {@link AiKeyRef} fingerprint — a raw API key must never become a map key, a log line, or
+ * anything else that outlives the request.
+ */
+@Slf4j
+@Component
+@Lazy
+public class AiModelDirectory {
+
+    private static final Duration TIMEOUT = Duration.ofSeconds(15);
+    private static final Duration CACHE_TTL = Duration.ofMinutes(10);
+    private static final int MAX_RESPONSE_BYTES = 2 * 1024 * 1024;
+
+    private static final String GOOGLE_MODELS_URL =
+            "https://generativelanguage.googleapis.com/v1beta/models?pageSize=1000";
+    private static final String ANTHROPIC_MODELS_URL = "https://api.anthropic.com/v1/models?limit=1000";
+    private static final String ANTHROPIC_VERSION = "2023-06-01";
+    private static final String OPENAI_DEFAULT_BASE_URL = "https://api.openai.com";
+
+    private record CacheEntry(List<String> models, Instant expiresAt) {}
+
+    private final Map<String, CacheEntry> cache = new ConcurrentHashMap<>();
+    private final ObjectMapper objectMapper;
+    private final WebClient webClient;
+
+    public AiModelDirectory(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+        this.webClient = WebClient.builder()
+                .codecs(codecs -> codecs.defaultCodecs().maxInMemorySize(MAX_RESPONSE_BYTES))
+                .build();
+    }
+
+    /**
+     * The chat models this key can use, best default first.
+     * <p>
+     * Errors are not swallowed here — the caller decides whether a provider that cannot be reached
+     * means an error or the built-in list.
+     */
+    public Mono<List<String>> listChatModels(AiProvider provider, String apiKey, String baseUrl) {
+        String cacheKey = cacheKey(provider, apiKey, baseUrl);
+        CacheEntry cached = cache.get(cacheKey);
+        if (cached != null && Instant.now().isBefore(cached.expiresAt())) {
+            return Mono.just(cached.models());
+        }
+        return fetch(provider, apiKey, baseUrl)
+                .map(models -> AiModelCatalog.ordered(provider, models))
+                .doOnNext(models -> {
+                    cache.put(cacheKey, new CacheEntry(models, Instant.now().plus(CACHE_TTL)));
+                    log.debug("[AI-MODELS] {} listed {} chat model(s) for key {}",
+                            provider, models.size(), AiKeyRef.of(apiKey));
+                });
+    }
+
+    private Mono<List<String>> fetch(AiProvider provider, String apiKey, String baseUrl) {
+        return switch (provider) {
+            case GOOGLE -> get(GOOGLE_MODELS_URL, headers -> headers.set("x-goog-api-key", apiKey))
+                    .map(this::parseGoogle);
+            case ANTHROPIC -> get(ANTHROPIC_MODELS_URL, headers -> {
+                headers.set("x-api-key", apiKey);
+                headers.set("anthropic-version", ANTHROPIC_VERSION);
+            }).map(this::parseOpenAiShaped);
+            case OPENAI, OPENAI_COMPATIBLE -> get(modelsUrl(baseUrl),
+                    headers -> headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey))
+                    .map(this::parseOpenAiShaped);
+        };
+    }
+
+    private Mono<String> get(String url, java.util.function.Consumer<HttpHeaders> headers) {
+        return webClient.get()
+                .uri(url)
+                .headers(headers::accept)
+                .retrieve()
+                .bodyToMono(String.class)
+                .timeout(TIMEOUT);
+    }
+
+    /**
+     * {@code /v1/models} on the given base. A base URL that already carries the version segment is
+     * left alone, because both spellings are common in the wild for OpenAI-compatible gateways.
+     * <p>
+     * Package-private, like the two parsers below: they carry the behaviour worth testing, and a
+     * test that calls them directly beats one that reflects into them.
+     */
+    static String modelsUrl(String baseUrl) {
+        String base = (baseUrl == null || baseUrl.isBlank()) ? OPENAI_DEFAULT_BASE_URL : baseUrl.trim();
+        while (base.endsWith("/")) {
+            base = base.substring(0, base.length() - 1);
+        }
+        return base.endsWith("/v1") ? base + "/models" : base + "/v1/models";
+    }
+
+    /**
+     * Google: {@code {"models":[{"name":"models/gemini-3.6-flash","supportedGenerationMethods":[...]}]}}.
+     * The capability list is the provider's own verdict on whether a model can hold a conversation,
+     * so it is trusted ahead of the id heuristic.
+     */
+    List<String> parseGoogle(String body) {
+        List<String> models = new ArrayList<>();
+        for (JsonNode model : arrayAt(body, "models")) {
+            String name = model.path("name").asString("");
+            String id = name.startsWith("models/") ? name.substring("models/".length()) : name;
+            Boolean generates = null;
+            JsonNode methods = model.path("supportedGenerationMethods");
+            if (methods.isArray()) {
+                generates = false;
+                for (JsonNode method : methods) {
+                    if ("generateContent".equals(method.asString(""))) {
+                        generates = true;
+                        break;
+                    }
+                }
+            }
+            if (AiModelCatalog.isChatModel(id, generates)) {
+                models.add(id);
+            }
+        }
+        return models;
+    }
+
+    /** OpenAI and Anthropic both answer {@code {"data":[{"id":"..."}]}}. */
+    List<String> parseOpenAiShaped(String body) {
+        List<String> models = new ArrayList<>();
+        for (JsonNode model : arrayAt(body, "data")) {
+            String id = model.path("id").asString("");
+            if (AiModelCatalog.isChatModel(id, null)) {
+                models.add(id);
+            }
+        }
+        return models;
+    }
+
+    private Iterable<JsonNode> arrayAt(String body, String field) {
+        JsonNode node = objectMapper.readTree(body).path(field);
+        return node.isArray() ? node : List.of();
+    }
+
+    /** Fingerprint, never the key itself — this value is held in a map for the cache's lifetime. */
+    private static String cacheKey(AiProvider provider, String apiKey, String baseUrl) {
+        return provider.name() + ':' + AiKeyRef.of(apiKey)
+                + (provider == AiProvider.OPENAI_COMPATIBLE ? ':' + modelsUrl(baseUrl) : "");
+    }
+}

--- a/openfilz-api/src/main/java/org/openfilz/dms/service/impl/AiSettingsServiceImpl.java
+++ b/openfilz-api/src/main/java/org/openfilz/dms/service/impl/AiSettingsServiceImpl.java
@@ -1,13 +1,17 @@
 package org.openfilz.dms.service.impl;
 
 import lombok.extern.slf4j.Slf4j;
+import org.openfilz.dms.dto.request.ListAiModelsRequest;
 import org.openfilz.dms.dto.request.SaveAiSettingsRequest;
 import org.openfilz.dms.dto.response.AiConnectionTestResult;
+import org.openfilz.dms.dto.response.AiModelsResponse;
 import org.openfilz.dms.dto.response.AiSettingsResponse;
 import org.openfilz.dms.entity.UserAiSettings;
 import org.openfilz.dms.enums.AiProvider;
 import org.openfilz.dms.repository.UserAiSettingsRepository;
 import org.openfilz.dms.service.AiSettingsService;
+import org.openfilz.dms.service.ai.AiModelCatalog;
+import org.openfilz.dms.service.ai.AiModelDirectory;
 import org.openfilz.dms.service.ai.UserChatClientResolver;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.context.annotation.Lazy;
@@ -20,6 +24,7 @@ import reactor.core.scheduler.Schedulers;
 
 import java.time.Duration;
 import java.time.OffsetDateTime;
+import java.util.List;
 
 /**
  * Implementation of the per-user BYOK settings. Keys are stored AES-256-GCM encrypted
@@ -36,15 +41,18 @@ public class AiSettingsServiceImpl implements AiSettingsService {
     private final UserAiSettingsRepository repository;
     private final AiSettingsCipher cipher;
     private final UserChatClientResolver resolver;
+    private final AiModelDirectory modelDirectory;
     private final Environment environment;
 
     public AiSettingsServiceImpl(UserAiSettingsRepository repository,
                                  AiSettingsCipher cipher,
                                  UserChatClientResolver resolver,
+                                 AiModelDirectory modelDirectory,
                                  Environment environment) {
         this.repository = repository;
         this.cipher = cipher;
         this.resolver = resolver;
+        this.modelDirectory = modelDirectory;
         this.environment = environment;
     }
 
@@ -137,6 +145,41 @@ public class AiSettingsServiceImpl implements AiSettingsService {
                     log.debug("AI connection test failed for {}: {}", request.provider(), e.toString());
                     return Mono.just(new AiConnectionTestResult(false, friendlyMessage(e), 0));
                 });
+    }
+
+    @Override
+    public Mono<AiModelsResponse> listModels(String userEmail, ListAiModelsRequest request) {
+        requireEnabled();
+        if (request.provider() == null) {
+            throw badRequest("provider is required");
+        }
+        AiProvider provider = request.provider();
+        List<String> builtIn = AiModelCatalog.fallback(provider);
+
+        return storedOrSubmittedKey(userEmail, request.apiKey())
+                .flatMap(apiKey -> modelDirectory.listChatModels(provider, apiKey, request.baseUrl()))
+                .map(models -> models.isEmpty()
+                        // A provider that answers with nothing usable is not an outage, but it is
+                        // not an answer either — offer the built-in list rather than an empty picker.
+                        ? AiModelsResponse.fallback(provider, builtIn, "Provider returned no chat models")
+                        : AiModelsResponse.live(provider, models))
+                // No key yet: the settings page asks as soon as a provider is picked, before the
+                // user has typed anything, and that is a normal state rather than an error.
+                .switchIfEmpty(Mono.just(AiModelsResponse.fallback(provider, builtIn,
+                        "Enter an API key to list the models your account can use")))
+                .onErrorResume(e -> {
+                    log.debug("[AI-MODELS] {} could not list models: {}", provider, e.toString());
+                    return Mono.just(AiModelsResponse.fallback(provider, builtIn, friendlyMessage(e)));
+                });
+    }
+
+    /** The submitted key, else the stored one, else empty — never an error: see {@link #listModels}. */
+    private Mono<String> storedOrSubmittedKey(String userEmail, String submitted) {
+        if (!isBlank(submitted)) {
+            return Mono.just(submitted.trim());
+        }
+        return repository.findById(userEmail)
+                .map(settings -> cipher.decrypt(settings.getApiKeyEncrypted()));
     }
 
     private void requireEnabled() {

--- a/openfilz-api/src/test/java/org/openfilz/dms/service/ai/AiModelCatalogTest.java
+++ b/openfilz-api/src/test/java/org/openfilz/dms/service/ai/AiModelCatalogTest.java
@@ -1,0 +1,105 @@
+package org.openfilz.dms.service.ai;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.openfilz.dms.enums.AiProvider;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Which of a provider's models reach the BYOK picker, and in what order.
+ * <p>
+ * The order is behaviour, not presentation: the settings page pre-fills the model field with the
+ * first entry, so whatever leads the list is what a user gets by default. OpenFilz shipped
+ * {@code gemini-2.5-flash} in that position until Google retired it and every BYOK chat answered
+ * {@code 404 ... no longer available to new users}.
+ */
+class AiModelCatalogTest {
+
+    /** Ids a real Gemini ListModels returns on a free-tier key. */
+    private static final List<String> GOOGLE_LIVE = List.of(
+            "gemini-2.5-flash", "gemini-2.5-pro", "gemma-4-31b-it", "gemini-flash-latest",
+            "gemini-pro-latest", "gemini-3.1-flash-lite", "gemini-3.5-flash", "gemini-3.5-flash-lite",
+            "gemini-3.6-flash", "gemini-3.7-flash");
+
+    @Test
+    @DisplayName("the pre-filled default leads the list, whatever order the provider used")
+    void preferredModelsLeadTheList() {
+        List<String> ordered = AiModelCatalog.ordered(AiProvider.GOOGLE, GOOGLE_LIVE);
+
+        assertThat(ordered).first().isEqualTo("gemini-3.6-flash");
+        assertThat(ordered).startsWith("gemini-3.6-flash", "gemini-3.7-flash", "gemini-3.5-flash");
+        assertThat(ordered).containsExactlyInAnyOrderElementsOf(GOOGLE_LIVE);
+        assertThat(ordered).doesNotHaveDuplicates();
+    }
+
+    @Test
+    @DisplayName("when the preferred model is retired the next known-good one leads — no release needed")
+    void orderingSelfHealsWhenAModelDisappears() {
+        List<String> withoutDefault = new ArrayList<>(GOOGLE_LIVE);
+        withoutDefault.remove("gemini-3.6-flash");
+
+        assertThat(AiModelCatalog.ordered(AiProvider.GOOGLE, withoutDefault))
+                .first().isEqualTo("gemini-3.7-flash");
+    }
+
+    @Test
+    @DisplayName("a provider offering nothing familiar still gets its own list, unfiltered by preference")
+    void unknownModelsAreStillOffered() {
+        List<String> exotic = List.of("some-future-model-9", "another-one");
+
+        assertThat(AiModelCatalog.ordered(AiProvider.GOOGLE, exotic)).isEqualTo(exotic);
+    }
+
+    @Test
+    @DisplayName("the provider's own capability verdict wins over the id")
+    void providerCapabilityDecidesWhereItIsGiven() {
+        assertThat(AiModelCatalog.isChatModel("gemini-3.6-flash", true)).isTrue();
+        assertThat(AiModelCatalog.isChatModel("gemini-3.6-flash", false)).isFalse();
+        // Null means the provider said nothing — OpenAI-shaped endpoints carry no capability info.
+        assertThat(AiModelCatalog.isChatModel("gpt-4o", null)).isTrue();
+    }
+
+    @Test
+    @DisplayName("non-chat models are kept out of a chat model picker")
+    void nonChatModelsAreFilteredOut() {
+        // These all advertise generateContent, so only the id distinguishes them.
+        assertThat(AiModelCatalog.isChatModel("gemini-2.5-flash-preview-tts", true)).isFalse();
+        assertThat(AiModelCatalog.isChatModel("gemini-2.5-flash-image", true)).isFalse();
+        assertThat(AiModelCatalog.isChatModel("nano-banana-pro-preview", true)).isFalse();
+        assertThat(AiModelCatalog.isChatModel("lyria-3-pro-preview", true)).isFalse();
+        assertThat(AiModelCatalog.isChatModel("gemini-robotics-er-2-preview", true)).isFalse();
+        assertThat(AiModelCatalog.isChatModel("gemini-2.5-computer-use-preview-10-2025", true)).isFalse();
+        assertThat(AiModelCatalog.isChatModel("text-embedding-3-small", null)).isFalse();
+        assertThat(AiModelCatalog.isChatModel("whisper-1", null)).isFalse();
+        assertThat(AiModelCatalog.isChatModel("dall-e-3", null)).isFalse();
+        assertThat(AiModelCatalog.isChatModel("omni-moderation-latest", null)).isFalse();
+    }
+
+    @Test
+    @DisplayName("the filter stays conservative — an unfamiliar chat model is not hidden")
+    void unfamiliarChatModelsSurvive() {
+        assertThat(AiModelCatalog.isChatModel("gemma-4-31b-it", true)).isTrue();
+        assertThat(AiModelCatalog.isChatModel("gemini-flash-latest", true)).isTrue();
+        assertThat(AiModelCatalog.isChatModel("mistral-large-2411", null)).isTrue();
+        assertThat(AiModelCatalog.isChatModel("", null)).isFalse();
+        assertThat(AiModelCatalog.isChatModel(null, null)).isFalse();
+    }
+
+    @Test
+    @DisplayName("no fallback list offers a model known to be retired")
+    void fallbackListsAreCurrent() {
+        assertThat(AiModelCatalog.fallback(AiProvider.GOOGLE))
+                .first().isEqualTo("gemini-3.6-flash");
+        assertThat(AiModelCatalog.fallback(AiProvider.GOOGLE))
+                .doesNotContain("gemini-2.5-flash", "gemini-2.5-pro");
+        // Nothing sensible to guess for an arbitrary gateway — the picker asks it instead.
+        assertThat(AiModelCatalog.fallback(AiProvider.OPENAI_COMPATIBLE)).isEmpty();
+        for (AiProvider provider : AiProvider.values()) {
+            assertThat(AiModelCatalog.fallback(provider)).doesNotHaveDuplicates();
+        }
+    }
+}

--- a/openfilz-api/src/test/java/org/openfilz/dms/service/ai/AiModelDirectoryTest.java
+++ b/openfilz-api/src/test/java/org/openfilz/dms/service/ai/AiModelDirectoryTest.java
@@ -1,0 +1,92 @@
+package org.openfilz.dms.service.ai;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Parsing the three "list models" responses, and the base-URL handling that decides where the
+ * OpenAI-shaped one is fetched from.
+ * <p>
+ * These exercise the parsing directly rather than through HTTP: the network call is three lines of
+ * WebClient, while the shape of each provider's answer — and what a malformed one must do — is the
+ * part that decides whether the picker works.
+ */
+class AiModelDirectoryTest {
+
+    private final AiModelDirectory directory = new AiModelDirectory(new ObjectMapper());
+
+    private List<String> parseGoogle(String body) {
+        return directory.parseGoogle(body);
+    }
+
+    private List<String> parseOpenAiShaped(String body) {
+        return directory.parseOpenAiShaped(body);
+    }
+
+    private String modelsUrl(String baseUrl) {
+        return AiModelDirectory.modelsUrl(baseUrl);
+    }
+
+    @Test
+    @DisplayName("Google: the models/ prefix is stripped and only chat models are kept")
+    void parsesGoogleListModels() {
+        String body = """
+                {"models":[
+                  {"name":"models/gemini-3.6-flash","supportedGenerationMethods":["generateContent","countTokens"]},
+                  {"name":"models/gemini-3.7-flash","supportedGenerationMethods":["generateContent"]},
+                  {"name":"models/gemini-2.5-flash-preview-tts","supportedGenerationMethods":["generateContent"]},
+                  {"name":"models/text-embedding-004","supportedGenerationMethods":["embedContent"]}
+                ]}""";
+
+        assertThat(parseGoogle(body)).containsExactly("gemini-3.6-flash", "gemini-3.7-flash");
+    }
+
+    @Test
+    @DisplayName("a model that cannot generate content is dropped even when its id looks fine")
+    void honoursSupportedGenerationMethods() {
+        String body = """
+                {"models":[{"name":"models/gemini-3.6-flash","supportedGenerationMethods":["countTokens"]}]}""";
+
+        assertThat(parseGoogle(body)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("OpenAI and Anthropic share a response shape; their non-chat catalogue is filtered")
+    void parsesOpenAiShapedListModels() {
+        String openai = """
+                {"data":[{"id":"gpt-4o"},{"id":"gpt-4o-mini"},{"id":"whisper-1"},
+                         {"id":"dall-e-3"},{"id":"text-embedding-3-small"}]}""";
+        assertThat(parseOpenAiShaped(openai)).containsExactly("gpt-4o", "gpt-4o-mini");
+
+        assertThat(parseOpenAiShaped("""
+                {"data":[{"id":"claude-opus-5"},{"id":"claude-haiku-4-5"}]}"""))
+                .containsExactly("claude-opus-5", "claude-haiku-4-5");
+    }
+
+    @Test
+    @DisplayName("a provider answer we cannot read yields no models rather than an exception")
+    void malformedResponsesDegradeQuietly() {
+        assertThat(parseGoogle("{}")).isEmpty();
+        assertThat(parseGoogle("{\"error\":{\"code\":403,\"message\":\"denied\"}}")).isEmpty();
+        assertThat(parseGoogle("{\"models\":\"not-an-array\"}")).isEmpty();
+        assertThat(parseGoogle("{\"models\":[{}]}")).isEmpty();
+        assertThat(parseOpenAiShaped("{\"data\":[]}")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("/v1/models is appended once, however the gateway's base URL is written")
+    void buildsTheModelsUrl() {
+        assertThat(modelsUrl(null)).isEqualTo("https://api.openai.com/v1/models");
+        assertThat(modelsUrl("   ")).isEqualTo("https://api.openai.com/v1/models");
+        assertThat(modelsUrl("https://llm.internal")).isEqualTo("https://llm.internal/v1/models");
+        assertThat(modelsUrl("https://llm.internal/")).isEqualTo("https://llm.internal/v1/models");
+        // Both spellings are common for OpenAI-compatible gateways, so /v1 must not be doubled.
+        assertThat(modelsUrl("https://llm.internal/v1")).isEqualTo("https://llm.internal/v1/models");
+        assertThat(modelsUrl("https://llm.internal/v1/")).isEqualTo("https://llm.internal/v1/models");
+    }
+}


### PR DESCRIPTION
Pairs with openfilz-web#`claude/openfilz-postgres-deploy-n2mwtp` — this adds the endpoint, that consumes it.

## Why

The BYOK model picker offered a list compiled into the release, which is the wrong shape for the problem: providers add and retire models continuously, so such a list is wrong the moment they do. OpenFilz shipped `gemini-2.5-flash` as the Google default until Google retired it, and every BYOK chat on it then answered `404 . This model ... is no longer available to new users`.

## The endpoint

`POST /api/v1/settings/ai/models` → `{ provider, models[], source: LIVE|FALLBACK, message? }`

- **POST, not GET** — the key travels in the body. A query string ends up in access logs and browser history. Omit `apiKey` to use the stored one, which is what the settings page does once a key is saved.
- **Plain HTTP, not the provider SDKs** — three trivial GETs (`/v1beta/models`, `/v1/models`, `/v1/models`), no provider types on this path (which GraalVM native images prefer), and any OpenAI-compatible gateway implementing `/v1/models` works with no extra code.
- **Filtering** — Google's `supportedGenerationMethods` is authoritative where it exists; otherwise the id decides. Providers return their whole catalogue (TTS, image, video, embeddings, robotics, computer-use) and a chat picker should not list it. The filter is deliberately conservative: the field stays free text, so leaving an odd model in costs nothing while hiding a wanted one does.
- **Cached** 10 minutes per (provider, key). The key is fingerprinted through `AiKeyRef` before becoming a cache key — a raw key must not outlive the request, in a map or anywhere else.
- **Never an error.** A provider that cannot be reached, a key not yet entered, or an empty answer all return the built-in list with `source=FALLBACK`, so the picker degrades to the old behaviour instead of blocking the form.

## Ordering is behaviour, not presentation

The caller pre-fills the model field with `models[0]`, so `AiModelCatalog` ranks the live list: known-good models the provider actually returned come first, then everything else in the provider's order.

This self-heals. When a preferred model disappears from the provider it simply stops matching and the next one that exists leads — no release needed. That is precisely the property the hardcoded list lacked.

## Also fixed

Two deployment defaults still named `gemini-2.5-flash` — `deploy/docker-compose/.env.example` and `deploy/helm/openfilz-api/values.yaml`. Anyone starting from either got a Google provider that could not answer at all. Both now default to `gemini-3.6-flash`, matching `application.yml`, and note that `gemini-flash-latest` tracks the current model for anyone who would rather not pin one.

## Verification

The repo targets Java 25 and only 21 is available in this environment, so the Maven build runs in CI. Both new classes were compiled against the **real** spring-webflux 7.0.8, spring-web, reactor-core 3.8.6 and Jackson 3.1.4 jars — which also confirmed the `WebClient.builder().codecs(c -> c.defaultCodecs().maxInMemorySize(...))` chain resolves and executes — and exercised with **32 checks**:

- a Gemini `ListModels` response rebuilt from a real free-tier account: `models/` prefix stripped, embeddings dropped via `embedContent`, and the eight non-chat entries (TTS, image, nano-banana, lyria, robotics, computer-use) filtered out while `gemma-*` and the `-latest` aliases survive
- ordering leads with the server default, loses no model, has no duplicates, and falls to the next known-good id when the default is removed
- OpenAI/Anthropic shape, with `whisper-1`/`dall-e-3`/embeddings/moderation filtered
- base-URL handling for gateways: host only, trailing slash, and a base already carrying `/v1` — `/v1/models` appended exactly once in each case
- malformed provider answers (empty object, an `error` object, wrong type for the array, entries with no name) yield an empty list rather than an exception

Mirrored as `AiModelCatalogTest` and `AiModelDirectoryTest`. The parsers and `modelsUrl` are package-private seams so the tests call them directly rather than reflecting into them.

---
_Generated by [Claude Code](https://claude.ai/code/session_013KV23y5acwYwbhFLEa4DhK)_