### PR TITLE
fix(ai): never widen the AI document scope around the criteria (security)

### DIFF
--- a/openfilz-api/src/main/java/org/openfilz/dms/repository/graphql/ListFolderCriteria.java
+++ b/openfilz-api/src/main/java/org/openfilz/dms/repository/graphql/ListFolderCriteria.java
@@ -168,11 +168,35 @@ public class ListFolderCriteria {
         }
     }
 
+    /**
+     * Emit the folder-scope predicate, opening the WHERE clause only if there is one to emit.
+     * <p>
+     * The predicate is built aside first because {@link #appendParentIdFilter} may legitimately
+     * produce nothing — a search across every folder has no parent to scope by. Appending WHERE
+     * up front would then leave a dangling {@code WHERE} for the next filter to trip over.
+     *
+     * @return whether a predicate was written, i.e. whether the next filter must join with AND
+     */
     public boolean appendWhereParentIdFilter(String prefix, StringBuilder query, ListFolderRequest request) {
-        query.append(WHERE);
-        return appendParentIdFilter(prefix, query, request);
+        StringBuilder scope = new StringBuilder();
+        if(!appendParentIdFilter(prefix, scope, request)) {
+            return false;
+        }
+        query.append(WHERE).append(scope);
+        return true;
     }
 
+    /**
+     * The folder scope of a listing, and — in layers that have per-document access control — the
+     * access predicate that goes with it.
+     * <p>
+     * <b>Extension layers restricting documents per user must put that restriction here</b>, in
+     * every branch including the whole-tree one. This is the single method every caller routes
+     * through for scoping, which is why the enterprise overrides live here rather than in a
+     * separate hook that a new branch could forget to call.
+     *
+     * @return whether anything was written; false means "no scope predicate", not "no rows"
+     */
     public boolean appendParentIdFilter(String prefix, StringBuilder query, ListFolderRequest request) {
         if(request.id() != null) {
             if(Boolean.TRUE.equals(request.recursive())) {
@@ -190,6 +214,11 @@ public class ListFolderCriteria {
             } else {
                 sqlUtils.appendEqualsCriteria(prefix, PARENT_ID, query);
             }
+        } else if(Boolean.TRUE.equals(request.recursive())) {
+            // Every folder at every depth: no parent scope at all. Core has no per-document
+            // access control, so there is nothing else to constrain it by either — an extension
+            // layer that does MUST override this branch, or its documents go unfiltered.
+            return false;
         } else {
             sqlUtils.appendIsNullCriteria(prefix, PARENT_ID, query);
         }

--- a/openfilz-api/src/main/java/org/openfilz/dms/service/ai/AiDocumentQueryService.java
+++ b/openfilz-api/src/main/java/org/openfilz/dms/service/ai/AiDocumentQueryService.java
@@ -107,27 +107,17 @@ public class AiDocumentQueryService {
     }
 
     /**
-     * Apply the request's filters, honouring a whole-tree search.
+     * Apply the request's filters.
      * <p>
-     * {@link ListFolderCriteria} is written for a folder <em>listing</em>, where a null id means
-     * "the root level" and {@code recursive} only widens an id that was given. An AI search for
-     * {@code folder="all"} means something else entirely — every document at every depth — and
-     * arrives here as exactly that combination: no id, recursive true. Left to the shared
-     * criteria it silently became {@code parent_id IS NULL}, so a global search only ever saw
-     * root-level documents and the model had to walk the tree folder by folder, one LLM call per
-     * folder. Here that combination emits no parent predicate at all.
-     * <p>
-     * Handled in this service rather than in the shared criteria on purpose: the GraphQL contract
-     * documents {@code recursive} as "when true and id is set", and other callers rely on a null
-     * id meaning the root level.
+     * Always through {@link ListFolderCriteria#applyFilter}, never around it. A whole-tree search
+     * ({@code folder="all"}) needs no parent predicate, but in a layer with per-document access
+     * control the access predicate is written by the same method that writes the parent one — so
+     * skipping it to drop the parent scope would drop the access restriction with it, and hand
+     * the model every user's documents. The criteria owns that decision; this service only asks.
      */
     private void applyFilter(StringBuilder query, ListFolderRequest request) {
         criteria.checkFilter(request);
-        if (searchesWholeTree(request)) {
-            criteria.appendAllFilterExceptParentId(PREFIX, query, request, false);
-        } else {
-            criteria.applyFilter(PREFIX, query, request);
-        }
+        criteria.applyFilter(PREFIX, query, request);
     }
 
     /**

--- a/openfilz-api/src/test/java/org/openfilz/dms/service/ai/AiDocumentQueryScopeTest.java
+++ b/openfilz-api/src/test/java/org/openfilz/dms/service/ai/AiDocumentQueryScopeTest.java
@@ -10,6 +10,7 @@ import org.openfilz.dms.repository.graphql.ListFolderCriteria;
 import org.openfilz.dms.utils.SqlUtils;
 import tools.jackson.databind.ObjectMapper;
 
+import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -27,6 +28,12 @@ import static org.mockito.Mockito.mock;
  * <p>
  * These assert on the emitted SQL because the scope <em>is</em> the SQL: the parent-id predicate
  * (or its absence) is the whole behaviour under test.
+ * <p>
+ * The scope is decided inside {@link ListFolderCriteria}, never around it. An extension layer with
+ * per-document access control writes its access predicate in the same method that writes the
+ * parent one, so a caller that skipped the criteria to widen the scope would drop the access
+ * restriction with it — see {@code CollaborationListFolderCriteriaTest} in openfilz-enterprise,
+ * which asserts the enterprise predicate survives every scope including this one.
  */
 class AiDocumentQueryScopeTest {
 
@@ -43,20 +50,8 @@ class AiDocumentQueryScopeTest {
                 new PageCriteria("createdAt", SortOrder.DESC, 1, 50), recursive);
     }
 
-    /** Mirrors {@code AiDocumentQueryService#applyFilter}. */
+    /** Mirrors {@code AiDocumentQueryService#applyFilter} — straight through the criteria. */
     private String sql(ListFolderRequest request) {
-        StringBuilder query = new StringBuilder("select * from Documents d");
-        criteria.checkFilter(request);
-        if (request.id() == null && Boolean.TRUE.equals(request.recursive())) {
-            criteria.appendAllFilterExceptParentId(PREFIX, query, request, false);
-        } else {
-            criteria.applyFilter(PREFIX, query, request);
-        }
-        return query.toString();
-    }
-
-    /** What the shared criteria alone produces — the pre-fix behaviour. */
-    private String sqlFromSharedCriteriaAlone(ListFolderRequest request) {
         StringBuilder query = new StringBuilder("select * from Documents d");
         criteria.checkFilter(request);
         criteria.applyFilter(PREFIX, query, request);
@@ -75,9 +70,6 @@ class AiDocumentQueryScopeTest {
         // The remaining filters must still open the WHERE clause themselves.
         assertThat(sql).contains(" WHERE d.type").doesNotContain("WHERE AND");
         assertThat(sql.split(" WHERE ", -1)).hasSize(2);
-
-        // The production symptom this fixes: the shared criteria alone scoped it to the root.
-        assertThat(sqlFromSharedCriteriaAlone(all)).contains("d.parent_id is null");
     }
 
     @Test
@@ -86,7 +78,6 @@ class AiDocumentQueryScopeTest {
         ListFolderRequest root = request(null, false, null);
 
         assertThat(sql(root)).contains("d.parent_id is null");
-        assertThat(sql(root)).isEqualTo(sqlFromSharedCriteriaAlone(root));
     }
 
     @Test
@@ -95,7 +86,6 @@ class AiDocumentQueryScopeTest {
         ListFolderRequest named = request(FOLDER, false, null);
 
         assertThat(sql(named)).contains("d.parent_id = :parent_id");
-        assertThat(sql(named)).isEqualTo(sqlFromSharedCriteriaAlone(named));
     }
 
     @Test
@@ -104,7 +94,52 @@ class AiDocumentQueryScopeTest {
         ListFolderRequest deep = request(FOLDER, true, null);
 
         assertThat(sql(deep)).contains("WITH RECURSIVE descendants");
-        assertThat(sql(deep)).isEqualTo(sqlFromSharedCriteriaAlone(deep));
+    }
+
+    /**
+     * Stand-in for an extension layer with per-document access control, shaped exactly like
+     * {@code CollaborationListFolderCriteria} in openfilz-enterprise: the access predicate is
+     * written by the same method that writes the parent scope.
+     */
+    private static final class AccessControlledCriteria extends ListFolderCriteria {
+        static final String ACCESS = "(o.owner_id = :usrId or ds.user_id = :usrId) ";
+
+        AccessControlledCriteria(SqlUtils sqlUtils) { super(sqlUtils); }
+
+        @Override
+        public boolean appendParentIdFilter(String prefix, StringBuilder query, ListFolderRequest request) {
+            if (request.id() != null) {
+                query.append("d.parent_id = :parent_id and ").append(ACCESS);
+            } else if (Boolean.TRUE.equals(request.recursive())) {
+                query.append(ACCESS);
+            } else {
+                query.append("d.parent_id is null and ").append(ACCESS);
+            }
+            return true;
+        }
+    }
+
+    @Test
+    @DisplayName("an access-controlled layer keeps its predicate on every scope, the whole tree included")
+    void accessPredicateIsNeverBypassed() {
+        ListFolderCriteria secured = new AccessControlledCriteria(new SqlUtils(mock(ObjectMapper.class)));
+
+        // The whole-tree scope is the dangerous one: it has no parent predicate to hide behind,
+        // so an implementation that emitted nothing here would return every user's documents
+        // straight into the AI's prompt.
+        for (ListFolderRequest request : List.of(
+                request(null, true, "pdf"),      // folder="all"
+                request(null, false, null),      // root only
+                request(FOLDER, false, null),    // one folder
+                request(FOLDER, true, null))) {  // folder + subfolders
+            StringBuilder query = new StringBuilder("select * from Documents d");
+            secured.applyFilter(PREFIX, query, request);
+
+            assertThat(query.toString())
+                    .as("access predicate must survive every scope")
+                    .contains(AccessControlledCriteria.ACCESS);
+            assertThat(query.toString()).contains(" WHERE ").doesNotContain("WHERE AND");
+        }
     }
 
     @Test
@@ -115,7 +150,7 @@ class AiDocumentQueryScopeTest {
                 null, null, null, null, null, null, null, true, null, true);
 
         StringBuilder query = new StringBuilder("select count(*) from Documents d");
-        criteria.appendAllFilterExceptParentId(PREFIX, query, countAll, false);
+        criteria.applyFilter(PREFIX, query, countAll);
 
         assertThat(query.toString()).doesNotContain("parent_id");
         assertThat(query.toString()).contains("d.type = :type", "d.active = :active");


### PR DESCRIPTION
**Security fix.** Found while preparing the merge of the recent AI work into openfilz-enterprise.

## The leak

v1.2.25 widened a `folder="all"` search by calling `appendAllFilterExceptParentId` directly, skipping `appendParentIdFilter` to drop the parent scope:

```java
if (searchesWholeTree(request)) {
    criteria.appendAllFilterExceptParentId(PREFIX, query, request, false);   // skips the parent filter
}
```

Safe in core, which has no per-document access control. **Not safe in a layer that does.**

openfilz-enterprise's `CollaborationListFolderCriteria` writes its access predicate *inside* `appendParentIdFilter`:

```java
} else {
    query.append("((d.parent_id is null and o.owner_id = :usrId) or (ds.user_id = :usrId and ds.root is true)) ");
}
```

and `CollaborationAiDocumentQueryService` contributes only **LEFT** joins on `doc_owner` / `doc_share`, which filter nothing by themselves. So that method is the **only** restriction on the query. Skipping it would have produced:

```sql
select ... from Documents d
  LEFT JOIN doc_owner o ON o.doc_id = d.id AND o.owner_id = :usrId
  LEFT JOIN doc_share ds ON ds.doc_id = d.id AND (...)
WHERE d.type = :type AND d.active = :active          -- no ownership predicate at all
```

— every user's documents, returned in the AI's tool results and pasted into the model's prompt. `:usrId` still appears in the JOINs, so it would not even have failed loudly.

## The fix

The scope decision moves into `ListFolderCriteria`, where the access predicate already lives:

- `appendParentIdFilter` gains the whole-tree branch (no id + `recursive`); core returns `false` meaning "no predicate"
- `appendWhereParentIdFilter` builds the predicate aside and opens the `WHERE` only if there is one, so `false` leaves no dangling `WHERE`
- `AiDocumentQueryService` goes back to `criteria.applyFilter(...)`, with **no path around it**

An extension layer can no longer lose its restriction when a scope is added: the branch it must handle is inside the method it already overrides, not a separate hook it could forget to implement.

## Behaviour

| scope | SQL |
|---|---|
| `folder="root"` | unchanged, byte-identical |
| named folder | unchanged, byte-identical |
| id + `recursive` (the CTE) | unchanged, byte-identical |
| `folder="all"` | no parent predicate in core; **access predicate retained** in enterprise |

`recursive=true` with no id — which `document.graphqls` documents as meaningless ("when true and id is set"), and which previously collapsed to root-only — now means the whole tree, uniformly rather than only inside the AI service.

## Verification

Compiled the real `ListFolderCriteria` against a stand-in shaped exactly like the enterprise subclass — **19 checks**, including that `(o.owner_id = :usrId or ds.user_id = :usrId)` survives all four scopes with no dangling `WHERE`:

```
all folders -> select ... LEFT JOIN doc_owner o ... LEFT JOIN doc_share ds ...
               WHERE (o.owner_id = :usrId or ds.user_id = :usrId)
                 AND d.type = :type AND UPPER(d.name) LIKE :name AND d.active = :active
```

`AiDocumentQueryScopeTest` carries the same guard as a JUnit test, so core cannot silently regress the contract enterprise depends on. openfilz-enterprise's existing `AiSecurityCollaborationIT.queryDocuments_asUserA_neverListsOtherUsersDoc` — which calls `queryDocuments("all", …)` — would also have caught this end-to-end.

---
_Generated by [Claude Code](https://claude.ai/code/session_013KV23y5acwYwbhFLEa4DhK)_